### PR TITLE
Start of failing test for config paths

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,3 +27,15 @@ def config_root(data_root):
 
     # Delete it afterwards
     shutil.rmtree(config_path)
+
+
+@pytest.fixture
+def config_here():
+    here = Path(__file__).parent.parent
+
+    # Make a temporary copy where we're running from
+    shutil.copy(here / "inbuilt_cfgs" / "exp_mf_config.yml", here)
+
+    yield here
+
+    os.unlink(here / "exp_mf_config.yml")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,17 @@
-from minerva.utils import runner, AUX_CONFIGS, CONFIG, utils, visutils
+import os
+from minerva.utils import load_configs
 
 
-def test_config_path(config_root):
-    with open(config_root / "exp_mf_config.yml", "r") as config:
-        print(config.read())
+def test_config_path(config_root, config_here):
+    assert "tmp/config" in str(config_root)
+
+    # Still works because we are relative to inbuilt_cfgs here
+    base, aux = load_configs(config_root / "exp_mf_config.yml")
+    assert base
+    assert aux
+
+    base, aux = load_configs(config_here / "exp_mf_config.yml")
+    assert base
+    assert aux
+
+


### PR DESCRIPTION
* Adds a `conftest.py` for reusable test fixtures
* Adds a stub fixture and test that copies one of the default configs, loads it from a different path and deletes it

I was going to go on and add a failing test but couldn't break it this way as easily as i'd hoped - unintentionally passes as it all runs relative to `inbuilt_cfgs` - and lost sight of what it was most intended to test. Didn't want to start making copies of config formats in the test fixtures as that sort of thing can be a pain to maintain

The argparse in `utils/__init__.py` is odd but a reasonable compromise, i would settle for keeping it mostly as-is but with the conditional loading by path in a testable function.

