### PR TITLE
Suggested tiny change to remove the specific type annotation from PathLike hints

### DIFF
--- a/minerva/utils/config_load.py
+++ b/minerva/utils/config_load.py
@@ -64,7 +64,7 @@ def universal_path(path: Any) -> Path:
 
 
 def check_paths(
-    config: Optional[Union[str, PathLike[str]]], use_default_conf_dir: bool
+    config: Optional[Union[str, PathLike]], use_default_conf_dir: bool
 ) -> Tuple[str, Optional[str], Optional[Path]]:
     """Checks the path given for the config.
 

--- a/minerva/utils/utils.py
+++ b/minerva/utils/utils.py
@@ -114,7 +114,7 @@ IMAGERY_CONFIG_PATH: Union[str, Sequence[str]] = CONFIG["dir"]["configs"][
 ]
 
 DATA_CONFIG_PATH: Optional[Path]
-_data_config_path: Optional[Union[str, PathLike[str]]] = CONFIG["dir"]["configs"].get(
+_data_config_path: Optional[Union[str, PathLike]] = CONFIG["dir"]["configs"].get(
     "data_config"
 )
 if _data_config_path:


### PR DESCRIPTION
This looks like a python <3.9 specific issues and may even be fixed in later versions than 3.8.3 which we are using internally (or how did your 3.8 tests run in Actions?)

Without this change, anywhere importing from `minerva.utils` (and thus `config_load`) is throwing `TypeError: 'ABCMeta' object is not subscriptable`


