### PR TITLE
CircleCI Parallelisation Dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
         docker:
             - image: cimg/python:3.10.9-node
               user: root
-        parallelism: 2
+        parallelism: 4
         steps:
             - checkout
             - setup_remote_docker:


### PR DESCRIPTION
# CircleCI Parallelisation

Adds parallelisation to the CircleCI tests to reduce computation time using the `parallelism` key in the CircleCI `config.yml`.