### PR TITLE
Set a default value for knn cluster number

### DIFF
--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -1003,7 +1003,12 @@ class Trainer:
         self.model.eval()
 
         # Get the number of classes from the data config.
-        n_classes = len(AUX_CONFIGS["data_config"]["classes"])
+        try:
+            n_classes = len(AUX_CONFIGS["data_config"]["classes"])
+        except KeyError as err:
+            # Fall back to a reasonable default if we don't have a class list
+            print("No class list defined in `data_config`")
+            n_classes = 10
 
         batch_size = self.batch_size
 


### PR DESCRIPTION
In a setting where we don't have a `data_config` on a self-supervised model, weighted KNN validation falls over at 

`len(AUX_CONFIGS["data_config"]["classes"])`

This suggests a (hardcoded, arbitrary) value of the number of class clusters if we don't have a set listing - is there a more thoughtful way to do it, will this have drawbacks?
