### PR TITLE
Automate documentation build and publish on release

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -11,7 +11,7 @@ jobs:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
-            - name: Qodana Scan
+            - name: Qodana Scan 🔭
               uses: JetBrains/qodana-action@v2023.1.0
               with:
                   args: --baseline,qodana.sarif.json

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -9,13 +9,13 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v3
-            - name: Install dependencies
+            - name: Install dependencies 🛒
               run: |
                   pip install sphinx sphinx_rtd_theme
-            - name: Sphinx build
+            - name: Sphinx build 🛠
               run: |
                   sphinx-build doc _build
-            - name: Deploy
+            - name: Deploy 🚀
               uses: peaceiris/actions-gh-pages@v3
               if: ${{ github.event_name == 'release' && github.ref == 'refs/heads/main' }}
               with:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,25 @@
+---
+name: Docs
+on: [push, pull_request, workflow_dispatch, release]
+permissions:
+    contents: write
+jobs:
+    docs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v3
+            - name: Install dependencies
+              run: |
+                  pip install sphinx sphinx_rtd_theme
+            - name: Sphinx build
+              run: |
+                  sphinx-build doc _build
+            - name: Deploy
+              uses: peaceiris/actions-gh-pages@v3
+              if: ${{ github.event_name == 'release' && github.ref == 'refs/heads/main' }}
+              with:
+                  publish_branch: gh-pages
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: _build/
+                  force_orphan: true

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,6 +1,11 @@
 ---
 name: Docs
-on: [push, pull_request, workflow_dispatch, release]
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+    release:
 permissions:
     contents: write
 jobs:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -14,7 +14,7 @@ jobs:
                   pip install sphinx sphinx_rtd_theme
             - name: Sphinx build 🛠
               run: |
-                  sphinx-build doc _build
+                  sphinx-build docs _build
             - name: Deploy 🚀
               uses: peaceiris/actions-gh-pages@v3
               if: ${{ github.event_name == 'release' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,12 @@ jobs:
     pypi:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout
+            - name: Checkout 🛒
               uses: actions/checkout@v3
               with:
                   fetch-depth: 0
             - run: python3 -m pip install --upgrade build && python3 -m build
-            - name: Publish package
+            - name: Publish package 📖
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
-            - name: Test Py ${{ matrix.python-version }}
+            - name: Test Py ${{ matrix.python-version }} 🧪
               uses: collective/tox-action@main
               with:
                   python-version: ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+_build
 
 # PyBuilder
 target/

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,6 +1,6 @@
 ---
 version: '1.0'
-linter: jetbrains/qodana-python:2022.3-eap
+linter: jetbrains/qodana-python:2023.1-eap
 failThreshold: 10
 include:
     - name: CheckDependencyLicenses


### PR DESCRIPTION
* Added a new worflow `documentation.yaml` which will build and deploy the `sphinx` documentation on pushes to the main, dispatch and releases.
* Closes #182 