### PR TITLE
Merge `transform_params` and `sampler_params` into `dataset_params`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include minerva/inbuilt_cfgs *.yml
+include banner.txt

--- a/minerva/datasets.py
+++ b/minerva/datasets.py
@@ -457,39 +457,6 @@ def make_dataset(
 
         return _sub_dataset, str(sub_dataset_root)
 
-    def create_transforms(
-        this_transform_params: Any, key: str, data_type_key: Optional[str] = None
-    ) -> Optional[Any]:
-        """Construct transforms for samples returned from this sub-dataset -- if found.
-
-        Args:
-            this_transform_params (~typing.Any): Parameters defining the transforms for the dataset for the
-                whole mode of fitting.
-            key (str): The key for the transforms for this particular subdataset.
-            data_type_key (str): Optional; The type of data the transform is acting on.
-                Most likely ``"image"`` or ``"mask"``. This may differ from ``key`` if using unionisation of datasets.
-                If ``None``, defaults to ``key``.
-
-        Returns:
-            ~typing.Any | None: The transformatins for this subdataset or ``None`` if no parameters found.
-        """
-        data_type_key = key if data_type_key is None else data_type_key
-
-        _transformations: Optional[Any] = None
-        if type(this_transform_params) == dict:
-            assert this_transform_params is not None
-            try:
-                if this_transform_params[key]:
-                    _transformations = make_transformations(
-                        this_transform_params[key], key=data_type_key
-                    )
-            except (KeyError, TypeError):
-                pass
-        else:
-            pass
-
-        return _transformations
-
     def create_subdataset(
         dataset_class: Callable[..., GeoDataset],
         root: str,

--- a/minerva/datasets.py
+++ b/minerva/datasets.py
@@ -981,8 +981,9 @@ def make_manifest(mf_config: Dict[Any, Any]) -> DataFrame:
     # sample the dataset. We need the original, un-transformed labels.
     for mode in dataset_params.keys():
         if "transforms" in dataset_params[mode]["mask"]:
-            if "ClassTransform" in dataset_params[mode]["mask"]["transforms"]:
-                del dataset_params[mode]["mask"]["transforms"]["ClassTransform"]
+            if type(dataset_params[mode]["mask"]["transforms"]) == dict:
+                if "ClassTransform" in dataset_params[mode]["mask"]["transforms"]:
+                    del dataset_params[mode]["mask"]["transforms"]["ClassTransform"]
 
     keys = list(dataset_params.keys())
     print("CONSTRUCTING DATASET")

--- a/minerva/datasets.py
+++ b/minerva/datasets.py
@@ -509,6 +509,8 @@ def make_dataset(
 
     # Iterate through all the sub-datasets defined in `dataset_params`.
     for type_key in dataset_params.keys():
+        if type_key == "sampler":
+            continue
         type_dataset_params = dataset_params[type_key]
 
         type_subdatasets = []
@@ -853,7 +855,7 @@ def make_loaders(
     # Gets out the parameters for the DataLoaders from params.
     dataloader_params: Dict[Any, Any] = params["loader_params"]
     dataset_params: Dict[str, Any] = params["dataset_params"]
-    sampler_params: Dict[str, Any] = params["sampler_params"]
+
     transform_params: Dict[str, Any] = params["transform_params"]
     batch_size: int = params["batch_size"]
 
@@ -899,15 +901,17 @@ def make_loaders(
                     "transform": forwards,
                 }
 
+        sampler_params: Dict[str, Any] = dataset_params[mode]["sampler"]
+
         # Calculates number of batches.
-        n_batches[mode] = int(sampler_params[mode]["params"]["length"] / batch_size)
+        n_batches[mode] = int(sampler_params["params"]["length"] / batch_size)
 
         # --+ MAKE DATASETS +=========================================================================================+
         print(f"CREATING {mode} DATASET")
         loaders[mode] = construct_dataloader(
             params["dir"]["data"],
             dataset_params[mode],
-            sampler_params[mode],
+            sampler_params,
             dataloader_params,
             batch_size,
             collator_params=params["collator"],
@@ -1007,15 +1011,18 @@ def make_manifest(mf_config: Dict[Any, Any]) -> DataFrame:
     batch_size = mf_config["batch_size"]
     dataloader_params = mf_config["dataloader_params"]
     dataset_params = mf_config["dataset_params"]
-    sampler_params = mf_config["sampler_params"]
+
     collator_params = mf_config["collator"]
 
     keys = list(dataset_params.keys())
     print("CONSTRUCTING DATASET")
+
+    sampler_params = dataset_params[keys[0]]["sampler"]
+
     loader = construct_dataloader(
         mf_config["dir"]["data"],
         dataset_params[keys[0]],
-        sampler_params[keys[0]],
+        sampler_params,
         dataloader_params,
         batch_size,
         collator_params=collator_params,

--- a/minerva/datasets.py
+++ b/minerva/datasets.py
@@ -841,6 +841,9 @@ def make_loaders(
         manifest = get_manifest(get_manifest_path())
         class_dist = utils.modes_from_manifest(manifest)
 
+        print("manifest: ", manifest)
+        print("class dist: ", class_dist)
+
         # Finds the empty classes and returns modified classes, a dict to convert between the old and new systems
         # and new colours.
         new_classes, forwards, new_colours = utils.load_data_specs(

--- a/minerva/datasets.py
+++ b/minerva/datasets.py
@@ -391,11 +391,20 @@ def intersect_datasets(datasets: Sequence[GeoDataset]) -> IntersectionDataset:
     return master_dataset
 
 
-def unionise_datasets(datasets: Sequence[GeoDataset]) -> UnionDataset:
+def unionise_datasets(
+    datasets: Sequence[GeoDataset],
+    transforms: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+) -> UnionDataset:
     """Unionises a list of :class:`~torchgeo.datasets.GeoDataset` together to return a single dataset object.
 
     Args:
         datasets (list[~torchgeo.datasets.GeoDataset]): List of datasets to unionise together.
+        transforms (): Optional; Function that will transform any sample yielded from the union.
+
+    .. note::
+        The transforms of ``transforms`` will be applied to the sample after any transforms applied to it by
+        the constituent dataset of the union the dataset came from. Therefore, ``transforms`` needs to compatible
+        with all possible samples of the union.
 
     Returns:
         ~torchgeo.datasets.UnionDataset: Final dataset object representing an union of all the parsed datasets.
@@ -405,6 +414,7 @@ def unionise_datasets(datasets: Sequence[GeoDataset]) -> UnionDataset:
     for i in range(len(datasets) - 1):
         master_dataset = master_dataset | datasets[i + 1]
 
+    master_dataset.transforms = transforms
     assert isinstance(master_dataset, UnionDataset)
     return master_dataset
 
@@ -412,7 +422,6 @@ def unionise_datasets(datasets: Sequence[GeoDataset]) -> UnionDataset:
 def make_dataset(
     data_directory: Union[Iterable[str], str, Path],
     dataset_params: Dict[Any, Any],
-    transform_params: Optional[Dict[Any, Any]] = None,
     sample_pairs: bool = False,
 ) -> Tuple[Any, List[Any]]:
     """Constructs a dataset object from ``n`` sub-datasets given by the parameters supplied.
@@ -421,8 +430,6 @@ def make_dataset(
         data_directory (~typing.Iterable[str] | str | ~pathlib.Path]): List defining the path to the directory
             containing the data.
         dataset_params (dict[~typing.Any, ~typing.Any]): Dictionary of parameters defining each sub-datasets to be used.
-        transform_params: Optional; Dictionary defining the parameters of the transforms to perform
-            when sampling from the dataset.
         sample_pairs (bool): Optional; ``True`` if paired sampling. This will ensure paired samples are handled
             correctly in the datasets.
 
@@ -516,27 +523,23 @@ def make_dataset(
         type_subdatasets = []
 
         multi_datasets_exist = False
+        master_transforms: Optional[Any] = None
         for area_key in type_dataset_params.keys():
             if area_key in ("module", "name", "params", "root"):
                 multi_datasets_exist = False
                 continue
+            elif area_key == "transforms":
+                master_transforms = make_transformations(
+                    type_dataset_params[area_key], type_key
+                )
             else:
                 multi_datasets_exist = True
                 _subdataset, subdataset_root = get_subdataset(
                     type_dataset_params, area_key
                 )
-                transformations: Optional[Any] = None
-                try:
-                    assert transform_params
-                    if transform_params[type_key]:
-                        transformations = create_transforms(
-                            transform_params[type_key],
-                            area_key,
-                            type_key,
-                        )
-                except (KeyError, TypeError, AssertionError):
-                    pass
-
+                transformations = make_transformations(
+                    type_dataset_params[area_key].get("transforms", False), type_key
+                )
                 type_subdatasets.append(
                     create_subdataset(
                         _subdataset,
@@ -547,13 +550,13 @@ def make_dataset(
                 )
 
         if multi_datasets_exist:
-            sub_datasets.append(unionise_datasets(type_subdatasets))
+            sub_datasets.append(unionise_datasets(type_subdatasets, master_transforms))
         else:
             sub_datasets.append(
                 create_subdataset(
                     *get_subdataset(dataset_params, type_key),
                     type_dataset_params,
-                    create_transforms(transform_params, type_key),
+                    master_transforms,
                 )
             )
 
@@ -572,7 +575,6 @@ def construct_dataloader(
     dataloader_params: Dict[str, Any],
     batch_size: int,
     collator_params: Optional[Dict[str, Any]] = None,
-    transform_params: Optional[Dict[str, Any]] = None,
     rank: int = 0,
     world_size: int = 1,
     sample_pairs: bool = False,
@@ -590,8 +592,6 @@ def construct_dataloader(
         batch_size (int): Number of samples per (global) batch.
         collator_params (dict[str, ~typing.Any]): Optional; Dictionary of parameters defining the function to collate
             and stack samples from the sampler.
-        transform_params (dict[str, ~typing.Any]): Optional; Dictionary defining the parameters of the transforms
-            to perform when sampling from the dataset.
         rank (int): Optional; The rank of this process for distributed computing.
         world_size (int): Optional; The total number of processes within a distributed run.
         sample_pairs (bool): Optional; True if paired sampling. This will wrap the collation function
@@ -601,7 +601,7 @@ def construct_dataloader(
         ~torch.utils.data.DataLoader: Object to handle the returning of batched samples from the dataset.
     """
     dataset, subdatasets = make_dataset(
-        data_directory, dataset_params, transform_params, sample_pairs=sample_pairs
+        data_directory, dataset_params, sample_pairs=sample_pairs
     )
 
     # --+ MAKE SAMPLERS +=============================================================================================+
@@ -855,8 +855,6 @@ def make_loaders(
     # Gets out the parameters for the DataLoaders from params.
     dataloader_params: Dict[Any, Any] = params["loader_params"]
     dataset_params: Dict[str, Any] = params["dataset_params"]
-
-    transform_params: Dict[str, Any] = params["transform_params"]
     batch_size: int = params["batch_size"]
 
     model_type = params["model_type"]
@@ -886,20 +884,20 @@ def make_loaders(
     loaders = {}
 
     for mode in dataset_params.keys():
-        this_transform_params = transform_params[mode]
         if params.get("elim", False) and model_type != "siamese":
-            if type(this_transform_params["mask"]) != dict:
-                this_transform_params["mask"] = {
-                    "ClassTransform": {
-                        "module": "minerva.transforms",
-                        "transform": forwards,
-                    }
-                }
-            else:
-                this_transform_params["mask"]["ClassTransform"] = {
+            class_transform = {
+                "ClassTransform": {
                     "module": "minerva.transforms",
                     "transform": forwards,
                 }
+            }
+
+            if type(dataset_params[mode]["mask"].get("transforms")) != dict:
+                dataset_params[mode]["mask"]["transforms"] = class_transform
+            else:
+                dataset_params[mode]["mask"]["transforms"][
+                    "ClassTransform"
+                ] = class_transform["ClassTransform"]
 
         sampler_params: Dict[str, Any] = dataset_params[mode]["sampler"]
 
@@ -915,7 +913,6 @@ def make_loaders(
             dataloader_params,
             batch_size,
             collator_params=params["collator"],
-            transform_params=this_transform_params,
             rank=rank,
             world_size=world_size,
             sample_pairs=sample_pairs if mode == "train" else False,

--- a/minerva/datasets.py
+++ b/minerva/datasets.py
@@ -499,6 +499,7 @@ def make_dataset(
                 master_transforms = make_transformations(
                     type_dataset_params[area_key], type_key
                 )
+                print(master_transforms)
             else:
                 multi_datasets_exist = True
                 _subdataset, subdataset_root = get_subdataset(
@@ -845,6 +846,8 @@ def make_loaders(
         new_classes, forwards, new_colours = utils.load_data_specs(
             class_dist=class_dist, elim=params.get("elim", False)
         )
+
+    print(forwards)
 
     # Inits dicts to hold the variables and lists for train, validation and test.
     n_batches = {}

--- a/minerva/inbuilt_cfgs/example_3rd_party.yml
+++ b/minerva/inbuilt_cfgs/example_3rd_party.yml
@@ -96,6 +96,10 @@ dataset_params:
                 length: 120
 
         image:
+            transforms:
+                ToRGB:
+                    module: minerva.transforms
+
             images_1:
                 module: minerva.datasets
                 name: TstImgDataset
@@ -111,6 +115,9 @@ dataset_params:
                     res: 1.0
 
         mask:
+            transforms:
+                SingleLabel:
+                    module: minerva.transforms
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
@@ -128,6 +135,9 @@ dataset_params:
                 length: 32
 
         image:
+            transforms:
+                ToRGB:
+                    module: minerva.transforms
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -135,6 +145,9 @@ dataset_params:
                 res: 1.0
 
         mask:
+            transforms:
+                SingleLabel:
+                    module: minerva.transforms
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
@@ -152,6 +165,9 @@ dataset_params:
                 length: 32
 
         image:
+            transforms:
+                ToRGB:
+                    module: minerva.transforms
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -159,44 +175,14 @@ dataset_params:
                 res: 1.0
 
         mask:
+            transforms:
+                SingleLabel:
+                    module: minerva.transforms
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
             params:
                 res: 1.0
-
-# === TRANSFORM PARAMETERS ====================================================
-transform_params:
-    # Training Dataset Transforms
-    train:
-        image:
-            images_1:
-                ToRGB:
-                    module: minerva.transforms
-            image2:
-                ToRGB:
-                    module: minerva.transforms
-        mask:
-            SingleLabel:
-                module: minerva.transforms
-
-    # Validation Dataset Transforms
-    val:
-        image:
-            ToRGB:
-                module: minerva.transforms
-        mask:
-            SingleLabel:
-                module: minerva.transforms
-
-    # Test Dataset Transforms
-    test:
-        image:
-            ToRGB:
-                module: minerva.transforms
-        mask:
-            SingleLabel:
-                module: minerva.transforms
 
 # === PLOTTING OPTIONS ========================================================
 plots:

--- a/minerva/inbuilt_cfgs/example_3rd_party.yml
+++ b/minerva/inbuilt_cfgs/example_3rd_party.yml
@@ -87,6 +87,14 @@ collator:
 dataset_params:
     # Training Dataset
     train:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 120
+
         image:
             images_1:
                 module: minerva.datasets
@@ -111,6 +119,14 @@ dataset_params:
 
     # Validation Dataset
     val:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 32
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -127,6 +143,14 @@ dataset_params:
 
     # Test Dataset
     test:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 32
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -140,35 +164,6 @@ dataset_params:
             root: test_lc
             params:
                 res: 1.0
-
-# === SAMPLER PARAMETERS ======================================================
-sampler_params:
-    # Training Dataset Sampler
-    train:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 120
-
-    # Validation Dataset Sampler
-    val:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 32
-
-    # Test Dataset Sampler
-    test:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 32
 
 # === TRANSFORM PARAMETERS ====================================================
 transform_params:

--- a/minerva/inbuilt_cfgs/example_CNN_config.yml
+++ b/minerva/inbuilt_cfgs/example_CNN_config.yml
@@ -85,6 +85,14 @@ collator:
 dataset_params:
     # Training Dataset
     train:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 320
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -100,6 +108,14 @@ dataset_params:
 
     # Validation Dataset
     val:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 80
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -116,6 +132,14 @@ dataset_params:
 
     # Test Dataset
     test:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 160
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -129,35 +153,6 @@ dataset_params:
             root: test_lc
             params:
                 res: 1.0
-
-# === SAMPLER PARAMETERS ======================================================
-sampler_params:
-    # Training Dataset Sampler
-    train:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 320
-
-    # Validation Dataset Sampler
-    val:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 80
-
-    # Test Dataset Sampler
-    test:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 160
 
 
 # === TRANSFORM PARAMETERS ====================================================

--- a/minerva/inbuilt_cfgs/example_CNN_config.yml
+++ b/minerva/inbuilt_cfgs/example_CNN_config.yml
@@ -94,12 +94,20 @@ dataset_params:
                 length: 320
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
             params:
                 res: 1.0
         mask:
+            transforms:
+                SingleLabel:
+                    module: minerva.transforms
+                    mode: modal
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
@@ -117,6 +125,10 @@ dataset_params:
                 length: 80
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -124,6 +136,10 @@ dataset_params:
                 res: 1.0
 
         mask:
+            transforms:
+                SingleLabel:
+                    module: minerva.transforms
+                    mode: modal
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
@@ -141,6 +157,10 @@ dataset_params:
                 length: 160
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -148,47 +168,15 @@ dataset_params:
                 res: 1.0
 
         mask:
+            transforms:
+                SingleLabel:
+                    module: minerva.transforms
+                    mode: modal
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
             params:
                 res: 1.0
-
-
-# === TRANSFORM PARAMETERS ====================================================
-transform_params:
-    # Training Dataset Transforms
-    train:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask:
-            SingleLabel:
-                module: minerva.transforms
-                mode: modal
-
-    # Validation Dataset Transforms
-    val:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask:
-            SingleLabel:
-                module: minerva.transforms
-                mode: modal
-
-    # Test Dataset Transforms
-    test:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask:
-            SingleLabel:
-                module: minerva.transforms
-                mode: modal
 
 # === PLOTTING OPTIONS ========================================================
 plots:

--- a/minerva/inbuilt_cfgs/example_GeoCLR_config.yml
+++ b/minerva/inbuilt_cfgs/example_GeoCLR_config.yml
@@ -92,6 +92,15 @@ collator:
 dataset_params:
     # Training Dataset
     train:
+        sampler:
+            module: minerva.samplers
+            name: RandomPairGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 120
+                max_r: *max_r
+
         image:
             image1:
                 module: minerva.datasets
@@ -108,6 +117,14 @@ dataset_params:
 
     # Validation Dataset
     val:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 32
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -124,6 +141,14 @@ dataset_params:
 
     # Test Dataset
     test:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 32
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -138,35 +163,6 @@ dataset_params:
             params:
                 res: 1.0
 
-# === SAMPLER PARAMETERS ======================================================
-sampler_params:
-    # Training Dataset Sampler
-    train:
-        module: minerva.samplers
-        name: RandomPairGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 120
-            max_r: *max_r
-
-    # Validation Dataset Sampler
-    val:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 32
-
-    # Test Dataset Sampler
-    test:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 32
 
 # === TRANSFORM PARAMETERS ====================================================
 transform_params:

--- a/minerva/inbuilt_cfgs/example_GeoCLR_config.yml
+++ b/minerva/inbuilt_cfgs/example_GeoCLR_config.yml
@@ -102,6 +102,29 @@ dataset_params:
                 max_r: *max_r
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
+                RandomApply:
+                    p: 0.25
+                    RandomResizedCrop:
+                        module: torchvision.transforms
+                        size: *patch_size
+                DetachedColorJitter:
+                    module: minerva.transforms
+                    brightness: 0.8
+                    contrast: 0.8
+                    saturation: 0.8
+                    hue: 0.2
+                RandomHorizontalFlip:
+                    module: torchvision.transforms
+                RandomVerticalFlip:
+                    module: torchvision.transforms
+                GaussianBlur:
+                    module: torchvision.transforms
+                    kernel_size: 25
+
             image1:
                 module: minerva.datasets
                 name: TstImgDataset
@@ -162,43 +185,6 @@ dataset_params:
             root: test_lc
             params:
                 res: 1.0
-
-
-# === TRANSFORM PARAMETERS ====================================================
-transform_params:
-    # Training Dataset Transforms
-    train:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-            RandomApply:
-                p: 0.25
-                RandomResizedCrop:
-                    module: torchvision.transforms
-                    size: *patch_size
-            DetachedColorJitter:
-                module: minerva.transforms
-                brightness: 0.8
-                contrast: 0.8
-                saturation: 0.8
-                hue: 0.2
-            RandomHorizontalFlip:
-                module: torchvision.transforms
-            RandomVerticalFlip:
-                module: torchvision.transforms
-            GaussianBlur:
-                module: torchvision.transforms
-                kernel_size: 25
-
-    # Validation Dataset Transforms
-    val:
-        image: false
-        mask: false
-
-    test:
-        image: false
-        mask: false
 
 # === PLOTTING OPTIONS ========================================================
 plots:

--- a/minerva/inbuilt_cfgs/example_UNetR_config.yml
+++ b/minerva/inbuilt_cfgs/example_UNetR_config.yml
@@ -87,6 +87,14 @@ collator:
 dataset_params:
     # Training Dataset
     train:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 320
+
         image:
             module: torchgeo.datasets
             name: NAIP
@@ -102,6 +110,14 @@ dataset_params:
 
     # Validation Dataset
     val:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 80
+
         image:
             module: torchgeo.datasets
             name: NAIP
@@ -117,6 +133,13 @@ dataset_params:
 
     # Test Dataset
     test:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 160
         image:
             module: torchgeo.datasets
             name: NAIP
@@ -129,35 +152,6 @@ dataset_params:
             root: Chesapeake7
             params:
                 res: 1.0
-
-# === SAMPLER PARAMETERS ======================================================
-sampler_params:
-    # Training Dataset Sampler
-    train:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 320
-
-    # Validation Dataset Sampler
-    val:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 80
-
-    # Test Dataset Sampler
-    test:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 160
 
 
 # === TRANSFORM PARAMETERS ====================================================

--- a/minerva/inbuilt_cfgs/example_UNetR_config.yml
+++ b/minerva/inbuilt_cfgs/example_UNetR_config.yml
@@ -96,6 +96,10 @@ dataset_params:
                 length: 320
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: torchgeo.datasets
             name: NAIP
             root: NAIP 2013/Train
@@ -119,6 +123,10 @@ dataset_params:
                 length: 80
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: torchgeo.datasets
             name: NAIP
             root: NAIP 2013/Validation
@@ -141,6 +149,10 @@ dataset_params:
                 size: *patch_size
                 length: 160
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: torchgeo.datasets
             name: NAIP
             root: NAIP 2013/Test
@@ -152,33 +164,6 @@ dataset_params:
             root: Chesapeake7
             params:
                 res: 1.0
-
-
-# === TRANSFORM PARAMETERS ====================================================
-transform_params:
-    # Training Dataset Transforms
-    train:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask: false
-
-    # Validation Dataset Transforms
-    val:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask: false
-
-    # Test Dataset Transforms
-    test:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask: false
 
 # === PLOTTING OPTIONS ========================================================
 plots:

--- a/minerva/inbuilt_cfgs/example_autoencoder_config.yml
+++ b/minerva/inbuilt_cfgs/example_autoencoder_config.yml
@@ -88,6 +88,14 @@ collator:
 dataset_params:
     # Training Dataset
     train:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 32
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -104,6 +112,14 @@ dataset_params:
 
     # Validation Dataset
     val:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 16
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -120,6 +136,14 @@ dataset_params:
 
     # Test Dataset
     test:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 16
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -133,35 +157,6 @@ dataset_params:
             root: test_lc
             params:
                 res: 1.0
-
-# === SAMPLER PARAMETERS ======================================================
-sampler_params:
-    # Training Dataset Sampler
-    train:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 32
-
-    # Validation Dataset Sampler
-    val:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 16
-
-    # Test Dataset Sampler
-    test:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 16
 
 
 # === TRANSFORM PARAMETERS ====================================================

--- a/minerva/inbuilt_cfgs/example_autoencoder_config.yml
+++ b/minerva/inbuilt_cfgs/example_autoencoder_config.yml
@@ -97,6 +97,10 @@ dataset_params:
                 length: 32
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -121,6 +125,10 @@ dataset_params:
                 length: 16
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -145,6 +153,10 @@ dataset_params:
                 length: 16
 
         image:
+            transforms:
+                Normalise:
+                    module: minerva.transforms
+                    norm_value: 255
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -157,33 +169,6 @@ dataset_params:
             root: test_lc
             params:
                 res: 1.0
-
-
-# === TRANSFORM PARAMETERS ====================================================
-transform_params:
-    # Training Dataset Transforms
-    train:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask: false
-
-    # Validation Dataset Transforms
-    val:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask: false
-
-    # Test Dataset Transforms
-    test:
-        image:
-            Normalise:
-                module: minerva.transforms
-                norm_value: 255
-        mask: false
 
 # === PLOTTING OPTIONS ========================================================
 plots:

--- a/minerva/inbuilt_cfgs/example_config.yml
+++ b/minerva/inbuilt_cfgs/example_config.yml
@@ -86,6 +86,14 @@ collator:
 dataset_params:
     # Training Dataset
     train:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 120
+
         image:
             images_1:
                 module: minerva.datasets
@@ -110,6 +118,14 @@ dataset_params:
 
     # Validation Dataset
     val:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 32
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -126,6 +142,14 @@ dataset_params:
 
     # Test Dataset
     test:
+        sampler:
+            module: torchgeo.samplers
+            name: RandomGeoSampler
+            roi: false
+            params:
+                size: *patch_size
+                length: 32
+
         image:
             module: minerva.datasets
             name: TstImgDataset
@@ -139,35 +163,6 @@ dataset_params:
             root: test_lc
             params:
                 res: 1.0
-
-# === SAMPLER PARAMETERS ======================================================
-sampler_params:
-    # Training Dataset Sampler
-    train:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 120
-
-    # Validation Dataset Sampler
-    val:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 32
-
-    # Test Dataset Sampler
-    test:
-        module: torchgeo.samplers
-        name: RandomGeoSampler
-        roi: false
-        params:
-            size: *patch_size
-            length: 32
 
 # === TRANSFORM PARAMETERS ====================================================
 transform_params:

--- a/minerva/inbuilt_cfgs/example_config.yml
+++ b/minerva/inbuilt_cfgs/example_config.yml
@@ -95,6 +95,7 @@ dataset_params:
                 length: 120
 
         image:
+            transforms: false
             images_1:
                 module: minerva.datasets
                 name: TstImgDataset
@@ -110,6 +111,7 @@ dataset_params:
                     res: 1.0
 
         mask:
+            transforms: false
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
@@ -127,6 +129,7 @@ dataset_params:
                 length: 32
 
         image:
+            transforms: false
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -134,6 +137,7 @@ dataset_params:
                 res: 1.0
 
         mask:
+            transforms: false
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
@@ -151,6 +155,7 @@ dataset_params:
                 length: 32
 
         image:
+            transforms: false
             module: minerva.datasets
             name: TstImgDataset
             root: test_images
@@ -158,28 +163,12 @@ dataset_params:
                 res: 1.0
 
         mask:
+            transforms: false
             module: minerva.datasets
             name: TstMaskDataset
             root: test_lc
             params:
                 res: 1.0
-
-# === TRANSFORM PARAMETERS ====================================================
-transform_params:
-    # Training Dataset Transforms
-    train:
-        image: false
-        mask: false
-
-    # Validation Dataset Transforms
-    val:
-        image: false
-        mask: false
-
-    # Test Dataset Transforms
-    test:
-        image: false
-        mask: false
 
 # === PLOTTING OPTIONS ========================================================
 plots:

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -342,6 +342,7 @@ class Trainer:
         self.sample_pairs = sample_pairs
         self.model.determine_output_dim(sample_pairs=sample_pairs)
 
+        print(self.device)
         # Transfer to GPU.
         self.model.to(self.device)
 

--- a/minerva/utils/utils.py
+++ b/minerva/utils/utils.py
@@ -397,16 +397,13 @@ def _print_banner(print_func: Callable[..., None] = print) -> None:
 
     Args:
         print_func (~typing.Callable[..., None]): Function to use to print the banner. Defaults to :func:`print`.
-
-    Raises:
-        FileNotFoundError: If ``banner.txt`` cannot be found.
     """
     banner_path = Path(__file__).parent.parent.parent / "banner.txt"
     if banner_path.exists():
         with open(banner_path, "r") as f:
             print_func(f.read())
     else:  # pragma: no cover
-        raise FileNotFoundError("Cannot find the banner.txt file")
+        print(f"Cannot find the banner.txt file at: {banner_path}")
 
 
 @overload

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -209,15 +209,14 @@ def test_make_dataset() -> None:
 
     dataset_params = {
         "image": {
+            "transforms": {
+                "Normalise": {"module": "minerva.transforms", "norm_value": 255}
+            },
             "module": "minerva.datasets",
             "name": "TstImgDataset",
             "root": "test_images",
             "params": {"res": 10.0},
         }
-    }
-
-    transform_params = {
-        "image": {"Normalise": {"module": "minerva.transforms", "norm_value": 255}}
     }
 
     dataset_1, subdatasets_1 = mdt.make_dataset(data_dir, dataset_params)
@@ -226,7 +225,9 @@ def test_make_dataset() -> None:
     assert isinstance(dataset_1, TstImgDataset)
 
     dataset_2, subdatasets_2 = mdt.make_dataset(
-        data_dir, dataset_params, transform_params, sample_pairs=True
+        data_dir,
+        dataset_params,
+        sample_pairs=True,
     )
 
     assert isinstance(dataset_2, type(subdatasets_2[0]))
@@ -250,24 +251,14 @@ def test_make_dataset() -> None:
         },
     }
 
-    dataset_3, subdatasets_3 = mdt.make_dataset(
-        data_dir, dataset_params2, transform_params
-    )
+    dataset_3, subdatasets_3 = mdt.make_dataset(data_dir, dataset_params2)
     assert isinstance(dataset_3, IntersectionDataset)
     assert isinstance(subdatasets_3[0], UnionDataset)
     assert isinstance(subdatasets_3[1], UnionDataset)
 
-    transform_params_3 = {
-        "image": {
-            "image_1": transform_params["image"],
-            "image_2": transform_params["image"],
-        }
-    }
-
     dataset_4, subdatasets_4 = mdt.make_dataset(
         data_dir,
         dataset_params2,
-        transform_params_3,
         sample_pairs=True,
     )
     assert isinstance(dataset_4, IntersectionDataset)
@@ -282,6 +273,9 @@ def test_construct_dataloader() -> None:
 
     dataset_params = {
         "image": {
+            "transforms": {
+                "Normalise": {"module": "minerva.transforms", "norm_value": 255}
+            },
             "module": "minerva.datasets",
             "name": "TstImgDataset",
             "root": "test_images",
@@ -309,10 +303,6 @@ def test_construct_dataloader() -> None:
         },
     }
 
-    transform_params = {
-        "image": {"Normalise": {"module": "minerva.transforms", "norm_value": 255}}
-    }
-
     dataloader_params = {"num_workers": 2, "pin_memory": True}
 
     dataloader_1 = mdt.construct_dataloader(
@@ -328,7 +318,6 @@ def test_construct_dataloader() -> None:
         sampler_params_2,
         dataloader_params,
         batch_size,
-        transform_params=transform_params,
         sample_pairs=True,
     )
     dataloader_3 = mdt.construct_dataloader(


### PR DESCRIPTION
This PR changes the structure of the config files to reduce the amount of boilerplate and make it easier for users. 

> :warning: **This is a breaking change** from `v0.24`!  Configs using the old structure will result in errors.

* ✅ Closes #181 
* ⬆ Merges `sampler_params` into `dataset_params`.
* ⬆ Merges `transform_params` into `dataset_params`.
* ⬆ Reformatted `datasets.make_datasets` for the new structure.
* 🗑 Removed the now redundant `datasets.make_datasets.create_transforms` sub-method.

## Specify the `sampler`

```yaml
# === DATASET PARAMETERS ======================================================
dataset_params:
    # Training Dataset
    train:
        sampler:
            module: torchgeo.samplers
            name: RandomGeoSampler
            roi: false
            params:
                size: *patch_size
                length: 120

        image:
 # ...
```

## Specify Transforms

Transforms can be defined at each dataset level of a data type (`image`, `mask`) using the `transforms` key. For example, one can define a set of transforms to apply to all images by specifying the transforms under the `transforms` key under `image`:

```yaml
# === DATASET PARAMETERS ======================================================
dataset_params:
    # Training Dataset
    train:
        sampler:
            module: minerva.samplers
            name: RandomPairGeoSampler
            roi: false
            params:
                size: *patch_size
                length: 120
                max_r: *max_r

        image:
            transforms:
                Normalise:
                    module: minerva.transforms
                    norm_value: 255
                RandomApply:
                    p: 0.25
                    RandomResizedCrop:
                        module: torchvision.transforms
                        size: *patch_size
                DetachedColorJitter:
                    module: minerva.transforms
                    brightness: 0.8
                    contrast: 0.8
                    saturation: 0.8
                    hue: 0.2
#...
```

You can also specify transforms for individual datasets using the same syntax:

```yaml
#...
            image1:
                transforms:
                    RandomHorizontalFlip:
                        module: torchvision.transforms
                module: minerva.datasets
                name: TstImgDataset
                root: test_images
                params:
                    res: 1.0
            image2:
                transforms:
                    RandomVerticalFlip:
                        module: torchvision.transforms
                module: minerva.datasets
                name: TstImgDataset
                root: test_images
                params:
                    res: 1.0
``` 