### PR TITLE
Return a PairedUnionDataset when joining to one

### DIFF
--- a/minerva/datasets.py
+++ b/minerva/datasets.py
@@ -337,6 +337,27 @@ class PairedUnionDataset(UnionDataset):
         """
         return super().__getitem__(query[0]), super().__getitem__(query[1])
 
+    def __or__(self, other: "PairedDataset") -> "PairedUnionDataset":  # type: ignore[override]
+        """Take the union of a PairedUnionDataset and a :class:`PairedDataset`.
+
+        Args:
+            other (PairedDataset): Another dataset.
+
+        Returns:
+            PairedUnionDataset: A single dataset.
+
+        Raises:
+            ValueError: If ``other`` is not a :class:`PairedDataset`
+
+        .. versionadded:: 0.24
+        """
+        if not isinstance(other, PairedDataset):
+            raise ValueError(
+                f"Unionising a dataset of {type(other)} and a PairedUnionDataset is not supported!"
+            )
+
+        return PairedUnionDataset(self, other)
+
 
 # =====================================================================================================================
 #                                                     METHODS

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -161,6 +161,12 @@ def test_join_paired_union_datasets(img_root: Path) -> None:
     union_dataset2 = union_dataset1 | dataset3
     assert isinstance(union_dataset2, PairedUnionDataset)
 
+    with pytest.raises(
+        ValueError,
+        match=f"Unionising a dataset of {type(dataset2)} and a PairedUnionDataset is not supported!",
+    ):
+        _ = union_dataset1 | dataset2  # type: ignore[operator]
+
 
 def test_get_collator() -> None:
     collator_params_1 = {"module": "torchgeo.datasets.utils", "name": "stack_samples"}

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -152,6 +152,16 @@ def test_paired_union_datasets(img_root: Path) -> None:
         dataset_test(dataset)
 
 
+def test_join_paired_union_datasets(img_root: Path) -> None:
+    dataset1 = TstImgDataset(str(img_root))
+    dataset2 = TstImgDataset(str(img_root))
+    dataset3 = PairedDataset(TstImgDataset, img_root)
+
+    union_dataset1 = PairedUnionDataset(dataset1, dataset2)
+    union_dataset2 = union_dataset1 | dataset3
+    assert isinstance(union_dataset2, PairedUnionDataset)
+
+
 def test_get_collator() -> None:
     collator_params_1 = {"module": "torchgeo.datasets.utils", "name": "stack_samples"}
     collator_params_2 = {"name": "stack_sample_pairs"}


### PR DESCRIPTION
`PairedUnionDataset` inherits interfaces from `torchgeo UnionDataset` which [in turn inherits `GeoDataset`](https://github.com/microsoft/torchgeo/blob/65d1aba43e7de31a0b5131af04d4f37b8c775d39/torchgeo/datasets/geo.py#L135)  - nothing's over-riding its `__or__` method (used to join datasets) so ultimately it's always going to return a `UnionDataset` when called on a Paired one.

This is where [Minerva is overriding __or__ in PairedDataset](https://github.com/Pale-Blue-Dot-97/Minerva/blob/18f2b5f041f8de26365dd9fb0a5c61d7c1ca9b01/minerva/datasets.py#L207) so I suggest here, PairedUnionDataset needs to behave in the same way?

This was surfacing in [an issue here](https://github.com/Pale-Blue-Dot-97/Minerva/blob/18f2b5f041f8de26365dd9fb0a5c61d7c1ca9b01/minerva/datasets.py#L407) when passing more than two datasets as input - after the second time `master_dataset` gets cast back to `UnionDataset` causing "tuple has no intersects" when trying to get pairs from the index...

Contents

* Add the same __or__ override that `PairedDataset` has to `PairedUnionDataset`
* Add a test that checks the return type