### PR TITLE
Distributed train and validation on v0.26-dev

### DIFF
--- a/minerva/models/core.py
+++ b/minerva/models/core.py
@@ -318,7 +318,7 @@ class MinervaDataParallel(Module):  # pragma: no cover
         try:
             return super().__getattr__(name)
         except AttributeError:
-            return getattr(self.model.module, name)
+            return getattr(self.model, name)
 
     def __repr__(self) -> Any:
         return self.model.__repr__()

--- a/minerva/models/core.py
+++ b/minerva/models/core.py
@@ -296,6 +296,9 @@ class MinervaDataParallel(Module):  # pragma: no cover
     ) -> None:
         super(MinervaDataParallel, self).__init__()
         self.model = paralleliser(model, *args, **kwargs).cuda()
+        # Set these so that epoch logging will use the wrapped model's values
+        self.output_shape = model.output_shape
+        self.n_classes = model.n_classes
 
     def forward(self, *inputs: Tuple[Tensor, ...]) -> Tuple[Tensor, ...]:
         """Ensures a forward call to the model goes to the actual wrapped model.
@@ -318,7 +321,7 @@ class MinervaDataParallel(Module):  # pragma: no cover
         try:
             return super().__getattr__(name)
         except AttributeError:
-            return getattr(self.model, name)
+            return getattr(self.model.module, name)
 
     def __repr__(self) -> Any:
         return self.model.__repr__()

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -1050,13 +1050,13 @@ class Trainer:
                 # Get features from passing the input data through the model.
                 if utils.check_substrings_in_string(self.model_type, "siamese"):
                     # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
-                    if dist.is_available() and dist.is_initialized():
+                    if isinstance(self.model, MinervaDataParallel):  # pragma: no cover
                         assert isinstance(self.model.model.module, MinervaSiamese)
                     else:
                         assert isinstance(self.model, MinervaSiamese)
 
                     # Ensures that the data is parsed through a single head of the model rather than paired.
-                    feature, _ = self.model.forward_single(val_data)
+                    feature, _ = self.model.forward_single(val_data)  # type: ignore[operator]
                 else:
                     feature, _ = self.model(val_data)
 
@@ -1087,13 +1087,13 @@ class Trainer:
                 # Get features from passing the input data through the model.
                 if utils.check_substrings_in_string(self.model_type, "siamese"):
                     # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
-                    if dist.is_available() and dist.is_initialized():
+                    if isinstance(self.model, MinervaDataParallel):  # pragma: no cover
                         assert isinstance(self.model.model.module, MinervaSiamese)
                     else:
                         assert isinstance(self.model, MinervaSiamese)
 
                     # Ensures that the data is parsed through a single head of the model rather than paired.
-                    feature, _ = self.model.forward_single(test_data)
+                    feature, _ = self.model.forward_single(test_data)  # type: ignore[operator]
                 else:
                     feature, _ = self.model(test_data)
 
@@ -1255,11 +1255,9 @@ class Trainer:
         model = self.model
 
         # Checks if this is a distributed run.
-        if dist.is_available() and dist.is_initialized():  # type: ignore[attr-defined]  # pragma: no cover
-            assert isinstance(model, MinervaDataParallel)
-
+        if isinstance(model, MinervaDataParallel):  # type: ignore[attr-defined]  # pragma: no cover
             # Extracts the actual model instance from the distributed wrapping.
-            model = model.model.module
+            model = model.model.module  # type: ignore[assignment]
 
         assert isinstance(model, MinervaModel)
         return model

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -1050,7 +1050,10 @@ class Trainer:
                 # Get features from passing the input data through the model.
                 if utils.check_substrings_in_string(self.model_type, "siamese"):
                     # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
-                    assert isinstance(self.model, MinervaSiamese)
+                    if dist.is_available() and dist.is_initialized():
+                        assert isinstance(self.model.model.module, MinervaSiamese)
+                    else:
+                        assert isinstance(self.model, MinervaSiamese)
 
                     # Ensures that the data is parsed through a single head of the model rather than paired.
                     feature, _ = self.model.forward_single(val_data)
@@ -1083,8 +1086,11 @@ class Trainer:
 
                 # Get features from passing the input data through the model.
                 if utils.check_substrings_in_string(self.model_type, "siamese"):
-                    # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
-                    assert isinstance(self.model, MinervaSiamese)
+                     # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
+                    if dist.is_available() and dist.is_initialized():
+                        assert isinstance(self.model.model.module, MinervaSiamese)
+                    else:
+                        assert isinstance(self.model, MinervaSiamese)
 
                     # Ensures that the data is parsed through a single head of the model rather than paired.
                     feature, _ = self.model.forward_single(test_data)

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -1253,7 +1253,7 @@ class Trainer:
             assert isinstance(model, MinervaDataParallel)
 
             # Extracts the actual model instance from the distributed wrapping.
-            model = model.model
+            model = model.model.module
 
         assert isinstance(model, MinervaModel)
         return model

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -1086,7 +1086,7 @@ class Trainer:
 
                 # Get features from passing the input data through the model.
                 if utils.check_substrings_in_string(self.model_type, "siamese"):
-                     # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
+                    # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
                     if dist.is_available() and dist.is_initialized():
                         assert isinstance(self.model.model.module, MinervaSiamese)
                     else:

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -1253,7 +1253,7 @@ class Trainer:
             assert isinstance(model, MinervaDataParallel)
 
             # Extracts the actual model instance from the distributed wrapping.
-            model = model.module
+            model = model.model
 
         assert isinstance(model, MinervaModel)
         return model


### PR DESCRIPTION
Small changes needed to run distributed training and validation.

Two commits:

* The first one sets `output_shape` and `n_classes` attributes on `MinervaDataParallel` (from the wrapped model) so that the epoch logger finds the values correctly
* The second one checks whether this is running distributed during the `weighted_knn_validation` task and conditionally type checks the wrapped model, not the outer one, before trying to run `forward_single`

I'm less sure about the second, as for me (testing on a 4xV100 instance) the validation task is taking a long time to run - 10 minutes before I got impatient, what would you typically expect? But thought I should flag up to you where I've been with this @Pale-Blue-Dot-97 