### PR TITLE
Torchgeo v0.5.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -37,7 +37,7 @@ starlette = ">=0.25.0" # not directly required, pinned by Dependabot to avoid a 
 tabulate = "==0.9.0"
 tensorflow = "==2.13.0"
 timm = "==0.9.2"
-torchgeo = {git = "https://github.com/microsoft/torchgeo"}
+torchgeo = "==0.5.0"
 torchinfo = "==1.8.0"
 tornado = ">=6.3.3"
 tqdm = "==4.66.1"

--- a/minerva/datasets/factory.py
+++ b/minerva/datasets/factory.py
@@ -120,17 +120,17 @@ def make_dataset(
             module_path=sub_dataset_params["module"], func=sub_dataset_params["name"]
         )
 
-        # Construct the root to the sub-dataset's files.
-        sub_dataset_root: Path = (
-            universal_path(data_directory) / sub_dataset_params["root"]
+        # Construct the path to the sub-dataset's files.
+        sub_dataset_path: Path = (
+            universal_path(data_directory) / sub_dataset_params["paths"]
         )
-        sub_dataset_root = sub_dataset_root.absolute()
+        sub_dataset_path = sub_dataset_path.absolute()
 
-        return _sub_dataset, str(sub_dataset_root)
+        return _sub_dataset, str(sub_dataset_path)
 
     def create_subdataset(
         dataset_class: Callable[..., GeoDataset],
-        root: str,
+        paths: Union[str, Iterable[str]],
         subdataset_params: Dict[Literal["params"], Dict[str, Any]],
         _transformations: Optional[Any],
     ) -> GeoDataset:
@@ -140,13 +140,13 @@ def make_dataset(
         if sample_pairs:
             return PairedDataset(
                 dataset_class,
-                root=root,
+                paths=paths,
                 transforms=_transformations,
                 **copy_params["params"],
             )
         else:
             return dataset_class(
-                root=root,
+                paths=paths,
                 transforms=_transformations,
                 **copy_params["params"],
             )
@@ -169,7 +169,7 @@ def make_dataset(
         master_transforms: Optional[Any] = None
         for area_key in type_dataset_params.keys():
             # If any of these keys are present, this must be a parameter set for a singular dataset at this level.
-            if area_key in ("module", "name", "params", "root"):
+            if area_key in ("module", "name", "params", "root", "paths"):
                 multi_datasets_exist = False
                 continue
 
@@ -187,7 +187,7 @@ def make_dataset(
             else:
                 multi_datasets_exist = True
 
-                _subdataset, subdataset_root = get_subdataset(
+                _subdataset, subdataset_paths = get_subdataset(
                     type_dataset_params, area_key
                 )
 
@@ -202,7 +202,7 @@ def make_dataset(
                 # Send the params for this area key back through this function to make the sub-dataset.
                 sub_dataset = create_subdataset(
                     _subdataset,
-                    subdataset_root,
+                    subdataset_paths,
                     type_dataset_params[area_key],
                     transformations,
                 )

--- a/minerva/inbuilt_cfgs/example_3rd_party.yml
+++ b/minerva/inbuilt_cfgs/example_3rd_party.yml
@@ -103,14 +103,14 @@ dataset_params:
             images_1:
                 module: minerva.datasets.__testing
                 name: TstImgDataset
-                root: NAIP
+                paths: NAIP
                 params:
                     res: 1.0
 
             image2:
                 module: minerva.datasets.__testing
                 name: TstImgDataset
-                root: NAIP
+                paths: NAIP
                 params:
                     res: 1.0
 
@@ -120,7 +120,7 @@ dataset_params:
                     module: minerva.transforms
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -140,7 +140,7 @@ dataset_params:
                     module: minerva.transforms
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
@@ -150,7 +150,7 @@ dataset_params:
                     module: minerva.transforms
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -170,7 +170,7 @@ dataset_params:
                     module: minerva.transforms
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
@@ -180,7 +180,7 @@ dataset_params:
                     module: minerva.transforms
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 

--- a/minerva/inbuilt_cfgs/example_CNN_config.yml
+++ b/minerva/inbuilt_cfgs/example_CNN_config.yml
@@ -100,7 +100,7 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
         mask:
@@ -110,7 +110,7 @@ dataset_params:
                     mode: modal
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -131,7 +131,7 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
@@ -142,7 +142,7 @@ dataset_params:
                     mode: modal
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -163,7 +163,7 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
@@ -174,7 +174,7 @@ dataset_params:
                     mode: modal
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 

--- a/minerva/inbuilt_cfgs/example_GeoCLR_config.yml
+++ b/minerva/inbuilt_cfgs/example_GeoCLR_config.yml
@@ -128,13 +128,13 @@ dataset_params:
             image1:
                 module: minerva.datasets.__testing
                 name: TstImgDataset
-                root: NAIP
+                paths: NAIP
                 params:
                     res: 1.0
             image2:
                 module: minerva.datasets.__testing
                 name: TstImgDataset
-                root: NAIP
+                paths: NAIP
                 params:
                     res: 1.0
 
@@ -151,14 +151,14 @@ dataset_params:
         image:
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -175,14 +175,14 @@ dataset_params:
         image:
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 

--- a/minerva/inbuilt_cfgs/example_GeoSimConvNet.yml
+++ b/minerva/inbuilt_cfgs/example_GeoSimConvNet.yml
@@ -128,13 +128,13 @@ dataset_params:
             image1:
                 module: minerva.datasets.__testing
                 name: TstImgDataset
-                root: NAIP
+                paths: NAIP
                 params:
                     res: 1.0
             image2:
                 module: minerva.datasets.__testing
                 name: TstImgDataset
-                root: NAIP
+                paths: NAIP
                 params:
                     res: 1.0
 
@@ -151,14 +151,14 @@ dataset_params:
         image:
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -175,14 +175,14 @@ dataset_params:
         image:
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 

--- a/minerva/inbuilt_cfgs/example_UNetR_config.yml
+++ b/minerva/inbuilt_cfgs/example_UNetR_config.yml
@@ -102,13 +102,13 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -129,13 +129,13 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -155,13 +155,13 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 

--- a/minerva/inbuilt_cfgs/example_autoencoder_config.yml
+++ b/minerva/inbuilt_cfgs/example_autoencoder_config.yml
@@ -103,14 +103,14 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -131,14 +131,14 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -159,14 +159,14 @@ dataset_params:
                     norm_value: 255
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
         mask:
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 

--- a/minerva/inbuilt_cfgs/example_config.yml
+++ b/minerva/inbuilt_cfgs/example_config.yml
@@ -99,14 +99,14 @@ dataset_params:
             images_1:
                 module: minerva.datasets.__testing
                 name: TstImgDataset
-                root: NAIP
+                paths: NAIP
                 params:
                     res: 1.0
 
             image2:
                 module: minerva.datasets.__testing
                 name: TstImgDataset
-                root: NAIP
+                paths: NAIP
                 params:
                     res: 1.0
 
@@ -114,7 +114,7 @@ dataset_params:
             transforms: false
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -132,7 +132,7 @@ dataset_params:
             transforms: false
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
@@ -140,7 +140,7 @@ dataset_params:
             transforms: false
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 
@@ -158,7 +158,7 @@ dataset_params:
             transforms: false
             module: minerva.datasets.__testing
             name: TstImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
 
@@ -166,7 +166,7 @@ dataset_params:
             transforms: false
             module: minerva.datasets.__testing
             name: TstMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 

--- a/minerva/inbuilt_cfgs/exp_mf_config.yml
+++ b/minerva/inbuilt_cfgs/exp_mf_config.yml
@@ -20,13 +20,13 @@ dataset_params:
         image:
             module: minerva.datasets.__testing
             name: TestImgDataset
-            root: NAIP
+            paths: NAIP
             params:
                 res: 1.0
         mask:
             module: minerva.datasets.__testing
             name: TestMaskDataset
-            root: Chesapeake7
+            paths: Chesapeake7
             params:
                 res: 1.0
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,7 +30,7 @@ starlette==0.31.1 # not directly required, pinned by Dependabot to avoid a vulne
 tabulate==0.9.0
 tensorflow==2.13.0
 timm==0.9.2
-torchgeo@git+https://github.com/microsoft/torchgeo
+torchgeo==0.5.0
 torchinfo==1.8.0
 tornado>=6.3.3
 tqdm==4.66.1

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -42,7 +42,7 @@ starlette>=0.25.0 # not directly required, pinned by Dependabot to avoid a vulne
 tabulate==0.9.0
 tensorflow==2.13.0
 timm==0.9.2
-torchgeo@git+https://github.com/microsoft/torchgeo
+torchgeo==0.5.0
 torchinfo==1.8.0
 tornado>=6.3.3
 tox==4.11.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -325,7 +325,7 @@ def exp_dataset_params() -> Dict[str, Any]:
             "transforms": {"AutoNorm": {"length": 12}},
             "module": "minerva.datasets.__testing",
             "name": "TstImgDataset",
-            "root": "NAIP",
+            "paths": "NAIP",
             "params": {"res": 1.0, "crs": 26918},
         }
     }

--- a/tests/test_datasets/test_dataset_utils.py
+++ b/tests/test_datasets/test_dataset_utils.py
@@ -65,7 +65,7 @@ def test_make_bounding_box() -> None:
 
 
 def test_intersect_datasets(img_root: Path, lc_root: Path) -> None:
-    imagery = PairedDataset(TstImgDataset, img_root)
-    labels = PairedDataset(TstMaskDataset, lc_root)
+    imagery = PairedDataset(TstImgDataset, str(img_root))
+    labels = PairedDataset(TstMaskDataset, str(lc_root))
 
     assert isinstance(mdt.intersect_datasets([imagery, labels]), IntersectionDataset)

--- a/tests/test_datasets/test_factory.py
+++ b/tests/test_datasets/test_factory.py
@@ -71,7 +71,7 @@ def test_make_dataset(exp_dataset_params: Dict[str, Any], data_root: Path) -> No
     exp_dataset_params["mask"] = {
         "module": "minerva.datasets.__testing",
         "name": "TstMaskDataset",
-        "root": "Chesapeake7",
+        "paths": "Chesapeake7",
         "params": {"res": 1.0},
     }
 

--- a/tests/test_datasets/test_paired.py
+++ b/tests/test_datasets/test_paired.py
@@ -52,7 +52,7 @@ from minerva.datasets.__testing import TstImgDataset
 #                                                       TESTS
 # =====================================================================================================================
 def test_paired_datasets(img_root: Path) -> None:
-    dataset1 = PairedDataset(TstImgDataset, img_root)
+    dataset1 = PairedDataset(TstImgDataset, str(img_root))
     dataset2 = TstImgDataset(str(img_root))
 
     with pytest.raises(
@@ -108,8 +108,8 @@ def test_paired_union_datasets(img_root: Path) -> None:
 
     dataset1 = TstImgDataset(str(img_root))
     dataset2 = TstImgDataset(str(img_root))
-    dataset3 = PairedDataset(TstImgDataset, img_root)
-    dataset4 = PairedDataset(TstImgDataset, img_root)
+    dataset3 = PairedDataset(TstImgDataset, str(img_root))
+    dataset4 = PairedDataset(TstImgDataset, str(img_root))
 
     union_dataset1 = PairedDataset(dataset1 | dataset2)
     union_dataset2 = dataset3 | dataset4

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -57,7 +57,7 @@ from minerva.samplers import (
 #                                                       TESTS
 # =====================================================================================================================
 def test_randompairgeosampler(img_root: Path) -> None:
-    dataset = PairedDataset(TstImgDataset, img_root, res=1.0)
+    dataset = PairedDataset(TstImgDataset, str(img_root), res=1.0)
 
     sampler = RandomPairGeoSampler(dataset, size=32, length=32, max_r=52)
     loader: DataLoader[Dict[str, Any]] = DataLoader(
@@ -73,7 +73,7 @@ def test_randompairgeosampler(img_root: Path) -> None:
 
 
 def test_randompairbatchgeosampler(img_root: Path) -> None:
-    dataset = PairedDataset(TstImgDataset, img_root, res=1.0)
+    dataset = PairedDataset(TstImgDataset, str(img_root), res=1.0)
 
     sampler = RandomPairBatchGeoSampler(
         dataset, size=32, length=32, batch_size=8, max_r=52, tiles_per_batch=1


### PR DESCRIPTION
Minor PR to update `torchgeo` --> `0.5.0` and rename `root` --> `paths` for input to `GeoDataset`.