### PR TITLE
Add Mixed-Precision Support

### DIFF
--- a/minerva/inbuilt_cfgs/example_GeoSimConvNet.yml
+++ b/minerva/inbuilt_cfgs/example_GeoSimConvNet.yml
@@ -26,10 +26,11 @@ model_name: SimConv-test
 model_type: siamese-segmentation
 
 # ---+ Sizing +----------------------------------------------------------------
-batch_size: 2                         # Number of samples in each batch.
-patch_size: &patch_size [32, 32]     # 2D tuple or float.
-input_size: &input_size [4, 32, 32]  # patch_size plus leading channel dim.
+batch_size: 2                          # Number of samples in each batch.
+patch_size: &patch_size [32, 32]       # 2D tuple or float.
+input_size: &input_size [4, 32, 32]    # patch_size plus leading channel dim.
 n_classes: &n_classes 8                # Number of classes in dataset.
+mix_precision: true                    # Activate mixed precision (16-bit)
 
 # ---+ Experiment Execution +--------------------------------------------------
 max_epochs: 4                         # Maximum number of training epochs.

--- a/minerva/logger/steplog.py
+++ b/minerva/logger/steplog.py
@@ -64,7 +64,7 @@ import torch
 import torch.distributed as dist
 from sklearn.metrics import jaccard_score
 from torch import Tensor
-from torchmetrics.regression import CosineSimilarity
+from torchmetrics.regression.cosine_similarity import CosineSimilarity
 
 if TYPE_CHECKING:  # pragma: no cover
     from torch.utils.tensorboard.writer import SummaryWriter

--- a/minerva/models/core.py
+++ b/minerva/models/core.py
@@ -203,13 +203,16 @@ class MinervaModel(Module, ABC):
         if train:
             self.optimiser.zero_grad()
 
+        z: Union[Tensor, Tuple[Tensor, ...]]
+        loss: Tensor
+
         if self.scaler:
-            with torch.cuda.amp.autocast():
+            with torch.cuda.amp.autocast_mode.autocast():
                 # Forward pass.
-                z: Union[Tensor, Tuple[Tensor, ...]] = self.forward(x)
+                z = self.forward(x)
 
                 # Compute Loss.
-                loss: Tensor = self.criterion(z, y)
+                loss = self.criterion(z, y)
 
             # Performs a backward pass if this is a training step.
             if train:
@@ -219,10 +222,10 @@ class MinervaModel(Module, ABC):
 
         else:
             # Forward pass.
-            z: Union[Tensor, Tuple[Tensor, ...]] = self.forward(x)
+            z = self.forward(x)
 
             # Compute Loss.
-            loss: Tensor = self.criterion(z, y)
+            loss = self.criterion(z, y)
 
             # Performs a backward pass if this is a training step.
             if train:

--- a/minerva/models/fcn.py
+++ b/minerva/models/fcn.py
@@ -57,6 +57,7 @@ from typing import Any, Dict, Literal, Optional, Sequence, Tuple
 import torch
 import torch.nn.modules as nn
 from torch import Tensor
+from torch.cuda.amp.grad_scaler import GradScaler
 
 from .core import MinervaBackbone, MinervaModel, bilinear_init, get_model
 
@@ -101,12 +102,16 @@ class FCN(MinervaBackbone):
         criterion: Any,
         input_size: Tuple[int, ...] = (4, 256, 256),
         n_classes: int = 8,
+        scaler: Optional[GradScaler] = None,
         backbone_weight_path: Optional[str] = None,
         freeze_backbone: bool = False,
         backbone_kwargs: Dict[str, Any] = {},
     ) -> None:
         super(FCN, self).__init__(
-            criterion=criterion, input_size=input_size, n_classes=n_classes
+            criterion=criterion,
+            input_size=input_size,
+            n_classes=n_classes,
+            scaler=scaler,
         )
 
         # Initialises the selected Minerva backbone.

--- a/minerva/models/siamese.py
+++ b/minerva/models/siamese.py
@@ -465,6 +465,7 @@ class SimConv(MinervaSiamese):
             input_size=input_size,
             criterion=None,
             n_classes=None,
+            scaler=None,
             **new_kwargs,
         )
 

--- a/minerva/models/siamese.py
+++ b/minerva/models/siamese.py
@@ -50,12 +50,13 @@ __all__ = [
 #                                                     IMPORTS
 # =====================================================================================================================
 import abc
-from typing import Any, Dict, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import numpy as np
 import torch
 import torch.nn.modules as nn
 from torch import Tensor
+from torch.cuda.amp.grad_scaler import GradScaler
 from torch.nn.modules import Module
 
 from .core import MinervaBackbone, MinervaModel, MinervaWrapper, get_model
@@ -169,9 +170,12 @@ class SimCLR(MinervaSiamese):
         criterion: Any,
         input_size: Tuple[int, int, int] = (4, 256, 256),
         feature_dim: int = 128,
+        scaler: Optional[GradScaler] = None,
         backbone_kwargs: Dict[str, Any] = {},
     ) -> None:
-        super(SimCLR, self).__init__(criterion=criterion, input_size=input_size)
+        super(SimCLR, self).__init__(
+            criterion=criterion, input_size=input_size, scaler=scaler
+        )
 
         self.backbone: MinervaModel = get_model(self.backbone_name)(
             input_size=input_size, encoder=True, **backbone_kwargs  # type: ignore[arg-type]
@@ -295,9 +299,12 @@ class SimSiam(MinervaSiamese):
         input_size: Tuple[int, int, int] = (4, 256, 256),
         feature_dim: int = 128,
         pred_dim: int = 512,
+        scaler: Optional[GradScaler] = None,
         backbone_kwargs: Dict[str, Any] = {},
     ) -> None:
-        super(SimSiam, self).__init__(criterion=criterion, input_size=input_size)
+        super(SimSiam, self).__init__(
+            criterion=criterion, input_size=input_size, scaler=scaler
+        )
 
         self.backbone: MinervaModel = get_model(self.backbone_name)(
             input_size=input_size, encoder=True, **backbone_kwargs  # type: ignore[arg-type]
@@ -434,9 +441,12 @@ class SimConv(MinervaSiamese):
         criterion: Any,
         input_size: Tuple[int, int, int] = (4, 256, 256),
         feature_dim: int = 2048,
+        scaler: Optional[GradScaler] = None,
         backbone_kwargs: Dict[str, Any] = {},
     ) -> None:
-        super(SimConv, self).__init__(criterion=criterion, input_size=input_size)
+        super(SimConv, self).__init__(
+            criterion=criterion, input_size=input_size, scaler=scaler
+        )
 
         # Set of required kwargs for the `PSPNet` adapted from `minerva` style kwargs.
         new_kwargs = {

--- a/minerva/models/unet.py
+++ b/minerva/models/unet.py
@@ -57,6 +57,7 @@ import torch
 import torch.nn.functional as F
 import torch.nn.modules as nn
 from torch import Tensor
+from torch.cuda.amp.grad_scaler import GradScaler
 from torch.nn.modules import Module
 
 from .core import MinervaModel, get_model
@@ -268,9 +269,13 @@ class UNet(MinervaModel):
         input_size: Tuple[int, ...] = (4, 256, 256),
         n_classes: int = 8,
         bilinear: bool = False,
+        scaler: Optional[GradScaler] = None,
     ) -> None:
         super(UNet, self).__init__(
-            criterion=criterion, input_size=input_size, n_classes=n_classes
+            criterion=criterion,
+            input_size=input_size,
+            n_classes=n_classes,
+            scaler=scaler,
         )
 
         self.bilinear = bilinear
@@ -353,12 +358,16 @@ class UNetR(MinervaModel):
         input_size: Tuple[int, ...] = (4, 256, 256),
         n_classes: int = 8,
         bilinear: bool = False,
+        scaler: Optional[GradScaler] = None,
         backbone_weight_path: Optional[str] = None,
         freeze_backbone: bool = False,
         backbone_kwargs: Dict[str, Any] = {},
     ) -> None:
         super(UNetR, self).__init__(
-            criterion=criterion, input_size=input_size, n_classes=n_classes
+            criterion=criterion,
+            input_size=input_size,
+            n_classes=n_classes,
+            scaler=scaler,
         )
 
         factor = 2 if bilinear else 1

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -434,6 +434,9 @@ class Trainer:
             # Updates the number of classes in case it has been altered by class balancing.
             params["num_classes"] = self.params["n_classes"]
 
+        if self.params.get("mix_precision", False):
+            params["scaler"] = torch.cuda.amp.grad_scaler.GradScaler()
+
         # Initialise model.
         model: MinervaModel
         if is_minerva:


### PR DESCRIPTION
## Add Mixed-Precision Support to `minerva`

* Closes #320 

Add the `mix_precision` at the global level of an experiment config to activate mixed-precision (16-bit rather than 32-bit floats):

```yaml
mix_precision: true
```

This will save memory and compute time while having negligible effects on the training accuracy. See [PyTorch](https://pytorch.org/blog/accelerating-training-on-nvidia-gpus-with-pytorch-automatic-mixed-precision/) for more details.