### PR TITLE
Fixed Pickling Error with `PairedDataset`

### DIFF
--- a/minerva/datasets/factory.py
+++ b/minerva/datasets/factory.py
@@ -178,7 +178,6 @@ def get_subdataset(
 
         if cached_dataset_path.exists():
             sub_dataset = load_dataset_from_cache(cached_dataset_path)
-            assert type(sub_dataset) == _sub_dataset  # noqa: E721
 
         else:
             sub_dataset = create_subdataset(

--- a/minerva/datasets/paired.py
+++ b/minerva/datasets/paired.py
@@ -84,6 +84,9 @@ class PairedDataset(RasterDataset):
         else:
             return super(PairedDataset, cls).__new__(cls)
 
+    def __getnewargs__(self):
+        return self.dataset, self._args, self._kwargs
+
     @overload
     def __init__(self, dataset: Callable[..., GeoDataset], *args, **kwargs) -> None:
         ...  # pragma: no cover
@@ -98,6 +101,10 @@ class PairedDataset(RasterDataset):
         *args,
         **kwargs,
     ) -> None:
+        # Needed for pickling/ unpickling.
+        self._args = args
+        self._kwargs = kwargs
+
         if isinstance(dataset, GeoDataset):
             self.dataset = dataset
             self._res = dataset.res

--- a/tests/test_datasets/test_factory.py
+++ b/tests/test_datasets/test_factory.py
@@ -107,7 +107,10 @@ def test_make_dataset(exp_dataset_params: Dict[str, Any], data_root: Path) -> No
     assert isinstance(subdatasets_5[0], UnionDataset)
 
 
-def test_caching_datasets(exp_dataset_params: Dict[str, Any], data_root: Path) -> None:
+@pytest.mark.parametrize("sample_pairs", (False, True))
+def test_caching_datasets(
+    exp_dataset_params: Dict[str, Any], data_root: Path, sample_pairs: bool
+) -> None:
     # Make the path to the cached dataset.
     cached_dataset_path = Path(
         CACHE_DIR, make_hash(exp_dataset_params["image"]) + ".obj"
@@ -118,7 +121,7 @@ def test_caching_datasets(exp_dataset_params: Dict[str, Any], data_root: Path) -
 
     # This first call will make the dataset from scratch then cache it.
     dataset_1, subdatasets_1 = mdt.make_dataset(
-        data_root, exp_dataset_params, cache=True
+        data_root, exp_dataset_params, sample_pairs=sample_pairs, cache=True
     )
 
     # The cached dataset should now exist.
@@ -126,11 +129,16 @@ def test_caching_datasets(exp_dataset_params: Dict[str, Any], data_root: Path) -
 
     # Second call to make dataset with the same args should now load that cached dataset.
     dataset_2, subdatasets_2 = mdt.make_dataset(
-        data_root, exp_dataset_params, cache=True
+        data_root, exp_dataset_params, sample_pairs=sample_pairs, cache=True
     )
 
     # Datasets from calls 1 should be the same as those from 2.
-    assert type(dataset_1) == type(dataset_2)  # noqa: E721
+    assert isinstance(dataset_1, type(dataset_2))
+    for i in range(len(subdatasets_1)):
+        assert isinstance(subdatasets_1[i], type(subdatasets_2[i]))
+
+    # Clean-up.
+    cached_dataset_path.unlink()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Fixed `PairedDataset` pickling error

This small PR adds a `__getnewargs__` method to `PairedDataset` which allows the default `__reduce__` method to function correctly when pickling and unpickling a `PairedDataset` instance.

* ✅ Closes #345 
* ✅ Closes #333 (fixes pickling bug due to caching `PairedDataset`)
* 🧪 Expands `test_caching_dataset` to cover paired sampling
* 🔴 Removes a problematic type check in loading datasets from cache