### PR TITLE
Added Torch Compile Support Back

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,3 @@ updates:
       directory: /
       schedule:
           interval: weekly
-
-    # Maintain pipenv Pipfile and lock file
-    - package-ecosystem: pip
-      directory: /
-      schedule:
-          interval: weekly

--- a/minerva/inbuilt_cfgs/example_3rd_party.yml
+++ b/minerva/inbuilt_cfgs/example_3rd_party.yml
@@ -36,6 +36,7 @@ pre_train: false                      # Activate pre-training mode.
 fine_tune: false                      # Activate fine-tuning mode.
 elim: false                           # Eliminates empty classes from schema.
 balance: false                        # Balances dataset classes.
+torch_compile: true                    # Wrap model in `torch.compile`.
 
 # ---+ Loss and Optimisers +---------------------------------------------------
 loss_func: &loss_func CrossEntropyLoss  # Name of the loss function to use.

--- a/minerva/inbuilt_cfgs/example_CNN_config.yml
+++ b/minerva/inbuilt_cfgs/example_CNN_config.yml
@@ -36,6 +36,7 @@ elim: false                           # Eliminates empty classes from schema.
 balance: false                        # Balances dataset classes.
 pre_train: false                      # Activate pre-training mode.
 fine_tune: false                      # Activate fine-tuning mode.
+torch_compile: true                    # Wrap model in `torch.compile`.
 
 # ---+ Loss and Optimisers +---------------------------------------------------
 loss_func: &loss_func CrossEntropyLoss  # Name of the loss function to use.

--- a/minerva/inbuilt_cfgs/example_GeoCLR_config.yml
+++ b/minerva/inbuilt_cfgs/example_GeoCLR_config.yml
@@ -35,6 +35,7 @@ elim: false                           # Eliminates empty classes from schema.
 balance: false                        # Balances dataset classes.
 pre_train: true                       # Activate pre-training mode.
 fine_tune: false                      # Activate fine-tuning mode.
+torch_compile: true                    # Wrap model in `torch.compile`.
 
 # ---+ Loss and Optimisers +---------------------------------------------------
 loss_func: &loss_func NTXentLoss      # Name of the loss function to use.

--- a/minerva/inbuilt_cfgs/example_GeoSimConvNet.yml
+++ b/minerva/inbuilt_cfgs/example_GeoSimConvNet.yml
@@ -26,14 +26,14 @@ model_name: SimConv-test
 model_type: siamese-segmentation
 
 # ---+ Sizing +----------------------------------------------------------------
-batch_size: 2                          # Number of samples in each batch.
-patch_size: &patch_size [32, 32]       # 2D tuple or float.
-input_size: &input_size [4, 32, 32]    # patch_size plus leading channel dim.
+batch_size: 1                          # Number of samples in each batch.
+patch_size: &patch_size [16, 16]       # 2D tuple or float.
+input_size: &input_size [4, 16, 16]    # patch_size plus leading channel dim.
 n_classes: &n_classes 8                # Number of classes in dataset.
 mix_precision: true                    # Activate mixed precision (16-bit)
 
 # ---+ Experiment Execution +--------------------------------------------------
-max_epochs: 4                         # Maximum number of training epochs.
+max_epochs: 2                         # Maximum number of training epochs.
 elim: false                           # Eliminates empty classes from schema.
 balance: false                        # Balances dataset classes.
 pre_train: true                       # Activate pre-training mode.
@@ -48,7 +48,7 @@ optim_func: SGD                           # Name of the optimiser function.
 sample_pairs: true                    # Activates Siamese paired sampling.
 max_r: &max_r 320   # Max distance between patches within a pair.
 knn_k: 5            # Top-k most similar images to predict image for KNN val
-val_freq: 2         # Validation epoch every ``val_freq`` training epochs.
+val_freq: 1         # Validation epoch every ``val_freq`` training epochs.
 
 # ---+ Model Parameters +------------------------------------------------------
 model_params:
@@ -105,7 +105,7 @@ tasks:
                 roi: false
                 params:
                     size: *patch_size
-                    length: 120
+                    length: 32
                     max_r: *max_r
 
             image:
@@ -161,7 +161,7 @@ tasks:
                     roi: false
                     params:
                         size: *patch_size
-                        length: 32
+                        length: 16
 
                 image:
                     module: minerva.datasets.__testing
@@ -184,7 +184,7 @@ tasks:
                     roi: false
                     params:
                         size: *patch_size
-                        length: 32
+                        length: 16
 
                 image:
                     module: minerva.datasets.__testing
@@ -218,7 +218,7 @@ tasks:
                 roi: false
                 params:
                     size: *patch_size
-                    length: 32
+                    length: 16
 
             image:
                 module: minerva.datasets.__testing

--- a/minerva/inbuilt_cfgs/example_GeoSimConvNet.yml
+++ b/minerva/inbuilt_cfgs/example_GeoSimConvNet.yml
@@ -31,6 +31,7 @@ patch_size: &patch_size [16, 16]       # 2D tuple or float.
 input_size: &input_size [4, 16, 16]    # patch_size plus leading channel dim.
 n_classes: &n_classes 8                # Number of classes in dataset.
 mix_precision: true                    # Activate mixed precision (16-bit)
+torch_compile: true                    # Wrap model in `torch.compile`.
 
 # ---+ Experiment Execution +--------------------------------------------------
 max_epochs: 2                         # Maximum number of training epochs.

--- a/minerva/inbuilt_cfgs/example_UNetR_config.yml
+++ b/minerva/inbuilt_cfgs/example_UNetR_config.yml
@@ -36,6 +36,7 @@ elim: true                            # Eliminates empty classes from schema.
 balance: true                         # Balances dataset classes.
 pre_train: false                      # Activate pre-training mode.
 fine_tune: false                      # Activate fine-tuning mode.
+torch_compile: true                    # Wrap model in `torch.compile`.
 
 # ---+ Loss and Optimisers +---------------------------------------------------
 loss_func: &loss_func CrossEntropyLoss  # Name of the loss function to use.

--- a/minerva/inbuilt_cfgs/example_autoencoder_config.yml
+++ b/minerva/inbuilt_cfgs/example_autoencoder_config.yml
@@ -37,6 +37,7 @@ balance: false                         # Balances dataset classes.
 pre_train: false                       # Activate pre-training mode.
 fine_tune: false                       # Activate fine-tuning mode.
 autoencoder_data_key: mask
+torch_compile: true                    # Wrap model in `torch.compile`.
 
 # ---+ Loss and Optimisers +---------------------------------------------------
 loss_func: &loss_func CrossEntropyLoss  # Name of the loss function to use.

--- a/minerva/inbuilt_cfgs/example_config.yml
+++ b/minerva/inbuilt_cfgs/example_config.yml
@@ -36,6 +36,7 @@ pre_train: false                      # Activate pre-training mode.
 fine_tune: false                      # Activate fine-tuning mode.
 elim: false                            # Eliminates empty classes from schema.
 balance: false                         # Balances dataset classes.
+torch_compile: true                    # Wrap model in `torch.compile`.
 
 # ---+ Optimisers +---------------------------------------------------
 lr: 1.0E-2                            # Learning rate of optimiser.
@@ -80,10 +81,6 @@ tasks:
         type: StandardEpoch
         train: true
         record_float: true
-        # ---+ Minerva Inbuilt Logging Functions +-------------------------
-        # logger: STGLogger
-        # metrics: SPMetrics
-        # model_io: sup_tg
 
         # ---+ Dataset Parameters +----------------------------------------
         dataset_params:

--- a/minerva/models/__init__.py
+++ b/minerva/models/__init__.py
@@ -41,6 +41,9 @@ __all__ = [
     "bilinear_init",
     "get_output_shape",
     "get_torch_weights",
+    "is_minerva_model",
+    "is_minerva_subtype",
+    "extract_wrapped_model",
     "FCN8ResNet18",
     "FCN8ResNet34",
     "FCN8ResNet50",
@@ -88,8 +91,11 @@ from .core import (
     MinervaOnnxModel,
     MinervaWrapper,
     bilinear_init,
+    extract_wrapped_model,
     get_output_shape,
     get_torch_weights,
+    is_minerva_model,
+    is_minerva_subtype,
 )
 from .fcn import (
     FCN8ResNet18,

--- a/minerva/models/core.py
+++ b/minerva/models/core.py
@@ -591,7 +591,7 @@ def extract_wrapped_model(
         assert isinstance(_model, (MinervaModel, MinervaDataParallel))
         model = _model
 
-    if isinstance(model, MinervaDataParallel):
+    if isinstance(model, MinervaDataParallel):  # pragma: no cover
         model = model.model.module
 
     assert isinstance(model, MinervaModel)

--- a/minerva/tasks/core.py
+++ b/minerva/tasks/core.py
@@ -53,6 +53,7 @@ import torch
 import torch.distributed as dist
 from nptyping import Int, NDArray
 from torch import Tensor
+from torch._dynamo.eval_frame import OptimizedModule
 from wandb.sdk.wandb_run import Run
 
 from minerva.datasets import make_loaders
@@ -154,7 +155,7 @@ class MinervaTask(ABC):
     def __init__(
         self,
         name: str,
-        model: Union[MinervaModel, MinervaDataParallel],
+        model: Union[MinervaModel, MinervaDataParallel, OptimizedModule],
         device: torch.device,
         exp_fn: Path,
         gpu: int = 0,

--- a/minerva/tasks/core.py
+++ b/minerva/tasks/core.py
@@ -95,6 +95,9 @@ class MinervaTask(ABC):
         record_int (bool): Store the integer results of each epoch in memory such the predictions, ground truth etc.
         record_float (bool): Store the floating point results of each epoch in memory
             such as the raw predicted probabilities.
+        train (bool): Mark this as a training task. Will activate backward passes.
+        task_dir (~pathlib.Path): Path to the sub-directory to hold the results of this task.
+        task_fn (~pathlib.Path): Path and filename prefix for this task.
 
     Args:
         name (str): The name of the task. Should match the key for the task
@@ -106,11 +109,10 @@ class MinervaTask(ABC):
         rank (int): Optional; The rank of this process across all devices in the distributed run.
         world_size (int): Optional; The total number of processes across the distributed run.
         writer (~wandb.sdk.wandb_run.Run | RunDisabled): Optional; Run object for Weights and Biases.
-        params (dict[str, ~typing.Any]): Dictionary describing all the parameters that define how the model will be
-            constructed, trained and evaluated. These should be defined via config ``YAML`` files.
         record_int (bool): Store the integer results of each epoch in memory such the predictions, ground truth etc.
         record_float (bool): Store the floating point results of each epoch in memory
             such as the raw predicted probabilities.
+        train (bool): Mark this as a training task. Will activate backward passes.
 
     Keyword Args:
         elim (bool): Will eliminate classes that have no samples in and reorder the class labels so they
@@ -144,7 +146,6 @@ class MinervaTask(ABC):
             :class:`~logger.steplog.MinervaStepLogger` class within :mod:`~logger.steplog`.
         modelio (str): Specify the IO function to use to handle IO for the model during fitting. Must be the name
             of a function within :mod:`modelio`.
-
 
     .. versionadded:: 0.27
     """

--- a/minerva/tasks/knn.py
+++ b/minerva/tasks/knn.py
@@ -55,7 +55,13 @@ if TYPE_CHECKING:  # pragma: no cover
 else:  # pragma: no cover
     SummaryWriter = None
 
-from minerva.models import MinervaDataParallel, MinervaModel, MinervaSiamese
+from minerva.models import (
+    MinervaDataParallel,
+    MinervaModel,
+    MinervaSiamese,
+    extract_wrapped_model,
+    is_minerva_subtype,
+)
 from minerva.utils import utils
 
 from .core import MinervaTask
@@ -181,10 +187,12 @@ class WeightedKNN(MinervaTask):
             # Get features from passing the input data through the model.
             if utils.check_substrings_in_string(self.model_type, "siamese"):
                 # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
-                if isinstance(self.model, MinervaDataParallel):  # pragma: no cover
-                    assert isinstance(self.model.model.module, MinervaSiamese)
+                if is_minerva_subtype(
+                    self.model, MinervaDataParallel
+                ):  # pragma: no cover
+                    assert isinstance(extract_wrapped_model(self.model), MinervaSiamese)
                 else:
-                    assert isinstance(self.model, MinervaSiamese)
+                    assert is_minerva_subtype(self.model, MinervaSiamese)
 
                 # Ensures that the data is parsed through a single head of the model rather than paired.
                 feature, _ = self.model.forward_single(val_data)  # type: ignore[operator]
@@ -235,10 +243,14 @@ class WeightedKNN(MinervaTask):
                 # Get features from passing the input data through the model.
                 if utils.check_substrings_in_string(self.model_type, "siamese"):
                     # Checks that the model is of type ``MinervaSiamese`` so a call to `forward_single` will work.
-                    if isinstance(self.model, MinervaDataParallel):  # pragma: no cover
-                        assert isinstance(self.model.model.module, MinervaSiamese)
+                    if is_minerva_subtype(
+                        self.model, MinervaDataParallel
+                    ):  # pragma: no cover
+                        assert isinstance(
+                            extract_wrapped_model(self.model), MinervaSiamese
+                        )
                     else:
-                        assert isinstance(self.model, MinervaSiamese)
+                        assert is_minerva_subtype(self.model, MinervaSiamese)
 
                     # Ensures that the data is parsed through a single head of the model rather than paired.
                     feature, _ = self.model.forward_single(test_data)  # type: ignore[operator]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -33,6 +33,7 @@ timm==0.9.2
 torch==2.1.1
 torchgeo==0.5.1
 torchinfo==1.8.0
+torchvision==0.16.1
 tornado>=6.3.3
 tqdm==4.66.1
 types-PyYAML==6.0.12.12

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,6 +30,7 @@ starlette==0.32.0.post1 # not directly required, pinned by Dependabot to avoid a
 tabulate==0.9.0
 tensorflow==2.14.0
 timm==0.9.2
+torch==2.1.1
 torchgeo==0.5.1
 torchinfo==1.8.0
 tornado>=6.3.3

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -45,6 +45,7 @@ timm==0.9.2
 torch==2.1.1
 torchgeo==0.5.1
 torchinfo==1.8.0
+torchvision==0.16.1
 tornado>=6.3.3
 tox==4.11.3
 tqdm==4.66.1

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -42,6 +42,7 @@ starlette>=0.25.0 # not directly required, pinned by Dependabot to avoid a vulne
 tabulate==0.9.0
 tensorflow==2.14.0
 timm==0.9.2
+torch==2.1.1
 torchgeo==0.5.1
 torchinfo==1.8.0
 tornado>=6.3.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,8 @@ from torchgeo.datasets import IntersectionDataset, RasterDataset
 from torchgeo.datasets.utils import BoundingBox
 
 from minerva.datasets import SSL4EOS12Sentinel2, make_dataset
-from minerva.models import CNN, MLP, FCN32ResNet18
+from minerva.loss import SegBarlowTwinsLoss
+from minerva.models import CNN, MLP, FCN32ResNet18, SimConv
 from minerva.utils import CONFIG, utils
 
 
@@ -204,6 +205,13 @@ def exp_fcn(
     std_n_classes: int,
 ) -> FCN32ResNet18:
     return FCN32ResNet18(x_entropy_loss, rgbi_input_size, std_n_classes)
+
+
+@pytest.fixture
+def exp_simconv(
+    rgbi_input_size: Tuple[int, int, int],
+) -> SimConv:
+    return SimConv(SegBarlowTwinsLoss(), rgbi_input_size, feature_dim=128)
 
 
 @pytest.fixture

--- a/tests/test_models/test_core.py
+++ b/tests/test_models/test_core.py
@@ -57,13 +57,11 @@ except (OSError, NewConnectionError, MaxRetryError):
     NTXentLoss = getattr(importlib.import_module("lightly.loss"), "NTXentLoss")
 from torch import LongTensor, Tensor
 from torch.nn.modules import Module
-from torch.nn.parallel import DataParallel as DP
 from torchvision.models._api import WeightsEnum
 from torchvision.models.resnet import resnet18
 
 from minerva.models import (
     MinervaBackbone,
-    MinervaDataParallel,
     MinervaModel,
     MinervaSiamese,
     MinervaWrapper,
@@ -231,11 +229,7 @@ def test_is_minerva_subtype(
     (lazy_fixture("exp_fcn"), lazy_fixture("exp_cnn"), lazy_fixture("exp_simconv")),
 )
 @pytest.mark.parametrize("compile_model", (True, False))
-@pytest.mark.parametrize("distributed", (True, False))
 def test_extract_wrapped_model(model, compile_model: bool, distributed: bool) -> None:
-    if distributed:
-        model = MinervaDataParallel(model, DP)
-
     if compile_model:
         model = torch.compile(model)
 

--- a/tests/test_models/test_core.py
+++ b/tests/test_models/test_core.py
@@ -229,7 +229,7 @@ def test_is_minerva_subtype(
     (lazy_fixture("exp_fcn"), lazy_fixture("exp_cnn"), lazy_fixture("exp_simconv")),
 )
 @pytest.mark.parametrize("compile_model", (True, False))
-def test_extract_wrapped_model(model, compile_model: bool, distributed: bool) -> None:
+def test_extract_wrapped_model(model, compile_model: bool) -> None:
     if compile_model:
         model = torch.compile(model)
 

--- a/tests/test_models/test_core.py
+++ b/tests/test_models/test_core.py
@@ -61,6 +61,8 @@ from torchvision.models._api import WeightsEnum
 from torchvision.models.resnet import resnet18
 
 from minerva.models import (
+    MinervaBackbone,
+    MinervaSiamese,
     MinervaWrapper,
     SimCLR18,
     bilinear_init,
@@ -200,3 +202,22 @@ def test_is_minerva_model(model: Module, compile_model: bool, answer: bool) -> N
         model = torch.compile(model)
 
     assert is_minerva_model(model) == answer
+
+
+@pytest.mark.parametrize(
+    ("model", "subtype", "answer"),
+    [
+        (lazy_fixture("exp_fcn"), MinervaBackbone, True),
+        (lazy_fixture("exp_cnn"), MinervaSiamese, False),
+        (lazy_fixture("exp_simconv"), MinervaSiamese, True),
+        (resnet18(), MinervaBackbone, False),
+    ],
+)
+@pytest.mark.parametrize("compile_model", (True, False))
+def test_is_minerva_subtype(
+    model: Module, subtype: type, compile_model: bool, answer: bool
+) -> None:
+    if compile_model:
+        model = torch.compile(model)
+
+    assert is_minerva_subtype(model, subtype) == answer

--- a/tests/test_models/test_core.py
+++ b/tests/test_models/test_core.py
@@ -37,6 +37,7 @@ __copyright__ = "Copyright (C) 2023 Harry Baker"
 #                                                      IMPORTS
 # =====================================================================================================================
 import importlib
+import os
 from typing import Tuple
 
 import internet_sabotage
@@ -199,7 +200,7 @@ def test_bilinear_init() -> None:
 )
 @pytest.mark.parametrize("compile_model", (True, False))
 def test_is_minerva_model(model: Module, compile_model: bool, answer: bool) -> None:
-    if compile_model:
+    if compile_model and os.name != "nt":
         model = torch.compile(model)
 
     assert is_minerva_model(model) == answer
@@ -218,7 +219,7 @@ def test_is_minerva_model(model: Module, compile_model: bool, answer: bool) -> N
 def test_is_minerva_subtype(
     model: Module, subtype: type, compile_model: bool, answer: bool
 ) -> None:
-    if compile_model:
+    if compile_model and os.name != "nt":
         model = torch.compile(model)
 
     assert is_minerva_subtype(model, subtype) == answer
@@ -230,7 +231,7 @@ def test_is_minerva_subtype(
 )
 @pytest.mark.parametrize("compile_model", (True, False))
 def test_extract_wrapped_model(model, compile_model: bool) -> None:
-    if compile_model:
+    if compile_model and os.name != "nt":
         model = torch.compile(model)
 
     assert isinstance(extract_wrapped_model(model), MinervaModel)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -43,7 +43,7 @@ from typing import Any, Dict
 import pytest
 import torch
 
-from minerva.models import MinervaModel, MinervaOnnxModel
+from minerva.models import MinervaModel, MinervaOnnxModel, is_minerva_subtype
 from minerva.trainer import Trainer
 from minerva.utils import CONFIG, config_load, runner, utils
 
@@ -125,9 +125,9 @@ def test_trainer_2() -> None:
 
     trainer2 = Trainer(0, **params2)
     if suffix == "onnx":
-        assert isinstance(trainer2.model, MinervaOnnxModel)
+        assert is_minerva_subtype(trainer2.model, MinervaOnnxModel)
     else:
-        assert isinstance(trainer2.model, MinervaModel)
+        assert is_minerva_subtype(trainer2.model, MinervaModel)
 
     trainer2.fit()
     trainer2.test()


### PR DESCRIPTION
Small PR that adds `torch.compile` support back into `minerva` now that `torch=2.1.1` has fixed support for `python=3.11`. As `torch.compile` 

* ✅ Closes #168 
* ✨ NEW: [`is_minerva_model`](https://github.com/Pale-Blue-Dot-97/Minerva/blob/839a199bfd3eda003771e4c243307b1068b50c55/minerva/models/core.py#L534) to check if a model is a Minerva model even if it is wrapped in `OptimizedModule`.
* ✨ NEW: [`is_minerva_subtype`](https://github.com/Pale-Blue-Dot-97/Minerva/blob/839a199bfd3eda003771e4c243307b1068b50c55/minerva/models/core.py#L554)
* ✨ NEW: [`extract_wrapped_model`](https://github.com/Pale-Blue-Dot-97/Minerva/blob/839a199bfd3eda003771e4c243307b1068b50c55/minerva/models/core.py#L574)
* 📦 Pinned `torch` --> `2.1.1`
* 📦 Pinned `torchvision` --> `0.16.1`