### PR TITLE
Switch to `torchseg`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "types-requests",
     "types-tabulate",
     "wandb",
-    "segmentation-models-pytorch",
+    "torchseg",
 ]
 
 [project.optional-dependencies]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -29,10 +29,10 @@ starlette==0.37.0 # not directly required, pinned by Dependabot to avoid a vulne
 tabulate==0.9.0
 tensorflow==2.15.0
 timm==0.9.12
+torch==2.2.0
 torchgeo==0.5.1
 torchinfo==1.8.0
 torchseg>=0.0.1a1
-torch==2.2.0
 torchvision==0.17.0
 tornado>=6.3.3
 tqdm==4.66.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -28,7 +28,7 @@ setuptools==69.0.3
 starlette==0.37.0 # not directly required, pinned by Dependabot to avoid a vulnerability.
 tabulate==0.9.0
 tensorflow==2.15.0
-timm==0.9.2
+timm==0.9.12
 torch==2.1.2
 torchgeo==0.5.1
 torchinfo==1.8.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,7 +24,6 @@ pyyaml==6.0.1
 rasterio>=1.3.6
 requests==2.31.0
 scikit-learn==1.4.0
-segmentation-models-pytorch==0.3.3
 setuptools==69.0.3
 starlette==0.37.0 # not directly required, pinned by Dependabot to avoid a vulnerability.
 tabulate==0.9.0
@@ -33,6 +32,7 @@ timm==0.9.2
 torch==2.1.2
 torchgeo==0.5.1
 torchinfo==1.8.0
+torchseg>=0.0.1a1
 torchvision==0.16.2
 tornado>=6.3.3
 tqdm==4.66.1

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -34,7 +34,6 @@ pyyaml==6.0.1
 rasterio>=1.3.6
 requests==2.31.0
 scikit-learn==1.4.0
-segmentation-models-pytorch==0.3.3
 setuptools==69.0.3
 sphinx==7.2.6
 sphinx-rtd-theme==2.0.0
@@ -45,6 +44,7 @@ timm==0.9.2
 torch==2.1.2
 torchgeo==0.5.1
 torchinfo==1.8.0
+torchseg>=0.0.1a1
 torchvision==0.16.2
 tornado>=6.3.3
 tox==4.12.1

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -40,7 +40,7 @@ sphinx-rtd-theme==2.0.0
 starlette>=0.25.0 # not directly required, pinned by Dependabot to avoid a vulnerability.
 tabulate==0.9.0
 tensorflow==2.15.0
-timm==0.9.2
+timm==0.9.12
 torch==2.1.2
 torchgeo==0.5.1
 torchinfo==1.8.0

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -41,12 +41,12 @@ starlette>=0.25.0 # not directly required, pinned by Dependabot to avoid a vulne
 tabulate==0.9.0
 tensorflow==2.15.0
 timm==0.9.12
-torchgeo==0.5.1
-torchinfo==1.8.0
-torchseg>=0.0.1a1
 torch==2.2.0
 torchgeo==0.5.1
+torchgeo==0.5.1
 torchinfo==1.8.0
+torchinfo==1.8.0
+torchseg>=0.0.1a1
 torchvision==0.17.0
 tornado>=6.3.3
 tox==4.12.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
         argcomplete
         mlflow
         wandb
-        segmentation-models-pytorch
+        torchseg
 python_requires = >=3.9
 package_dir =
 scripts = scripts/MinervaExp.py


### PR DESCRIPTION
Closes #439 by switching from using `segmentation_models_pytorch` to an actively maintained fork called `torchseg`

