### PR TITLE
Added Wandb Sweep Support

### DIFF
--- a/minerva/datasets/factory.py
+++ b/minerva/datasets/factory.py
@@ -155,6 +155,8 @@ def create_subdataset(
                 transforms=transformations,
                 **copy_params["params"],
             )
+        else:
+            raise TypeError
 
 
 def get_subdataset(
@@ -695,7 +697,7 @@ def make_loaders(
                 mode_sampler_params["params"].get(
                     "length",
                     mode_sampler_params["params"].get(
-                        "num_samples", len(loaders[mode].dataset)
+                        "num_samples", len(loaders[mode].dataset)  # type: ignore[arg-type]
                     ),
                 )
                 / batch_size

--- a/minerva/datasets/paired.py
+++ b/minerva/datasets/paired.py
@@ -338,22 +338,22 @@ class PairedNonGeoDataset(NonGeoDataset):
     .. versionadded:: 0.28
     """
 
-    def __new__(  # type: ignore[misc]
-        cls,
-        dataset: Union[
-            Callable[..., NonGeoDataset], NonGeoDataset, ConcatDataset[NonGeoDataset]
-        ],
-        size: Union[Tuple[int, int], int],
-        max_r: int,
-        *args,
-        **kwargs,
-    ) -> Union["PairedNonGeoDataset", "PairedConcatDataset"]:
-        if isinstance(dataset, ConcatDataset):
-            return PairedConcatDataset(
-                dataset.datasets[0], dataset.datasets[1], size, max_r, *args, **kwargs  # type: ignore[arg-type]
-            )
-        else:
-            return super(PairedNonGeoDataset, cls).__new__(cls)
+    # def __new__(  # type: ignore[misc]
+    #     cls,
+    #     dataset: Union[
+    #         Callable[..., NonGeoDataset], NonGeoDataset, ConcatDataset[NonGeoDataset]
+    #     ],
+    #     size: Union[Tuple[int, int], int],
+    #     max_r: int,
+    #     *args,
+    #     **kwargs,
+    # ) -> Union["PairedNonGeoDataset", "PairedConcatDataset"]:
+    #     if isinstance(dataset, ConcatDataset):
+    #         return PairedConcatDataset(
+    #             dataset.datasets[0], dataset.datasets[1], size, max_r, *args, **kwargs  # type: ignore[arg-type]
+    #         )
+    #     else:
+    #         return super(PairedNonGeoDataset, cls).__new__(cls)
 
     def __getnewargs__(self):
         return self.dataset, self.size, self.max_r, self._args, self._kwargs
@@ -397,6 +397,9 @@ class PairedNonGeoDataset(NonGeoDataset):
 
         self.size = size
         self.max_r = max_r
+
+        if isinstance(dataset, PairedNonGeoDataset):
+            raise ValueError("Cannot pair an already paired dataset!")
 
         if isinstance(dataset, NonGeoDataset):
             self.dataset = dataset
@@ -446,15 +449,15 @@ class PairedNonGeoDataset(NonGeoDataset):
         """
         return PairedConcatDataset(self, other)
 
-    def __getattr__(self, item):
-        if item == "dataset":
-            return self.dataset
-        elif item in self.dataset.__dict__:
-            return getattr(self.dataset, item)  # pragma: no cover
-        elif item in self.__dict__:
-            return getattr(self, item)
-        else:
-            raise AttributeError
+    # def __getattr__(self, item):
+    #     #if item == "dataset":
+    #     #    return self.dataset
+    #     if item in self.dataset.__dict__:
+    #         return getattr(self.dataset, item)  # pragma: no cover
+    #     elif item in self.__dict__:
+    #         return getattr(self, item)
+    #     else:
+    #         raise AttributeError
 
     def __len__(self) -> int:
         return self.dataset.__len__()

--- a/minerva/datasets/paired.py
+++ b/minerva/datasets/paired.py
@@ -49,7 +49,6 @@ from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union, overlo
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from torch import Tensor
-from torch.utils.data import ConcatDataset
 from torchgeo.datasets import (
     GeoDataset,
     IntersectionDataset,
@@ -338,23 +337,6 @@ class PairedNonGeoDataset(NonGeoDataset):
     .. versionadded:: 0.28
     """
 
-    # def __new__(  # type: ignore[misc]
-    #     cls,
-    #     dataset: Union[
-    #         Callable[..., NonGeoDataset], NonGeoDataset, ConcatDataset[NonGeoDataset]
-    #     ],
-    #     size: Union[Tuple[int, int], int],
-    #     max_r: int,
-    #     *args,
-    #     **kwargs,
-    # ) -> Union["PairedNonGeoDataset", "PairedConcatDataset"]:
-    #     if isinstance(dataset, ConcatDataset):
-    #         return PairedConcatDataset(
-    #             dataset.datasets[0], dataset.datasets[1], size, max_r, *args, **kwargs  # type: ignore[arg-type]
-    #         )
-    #     else:
-    #         return super(PairedNonGeoDataset, cls).__new__(cls)
-
     def __getnewargs__(self):
         return self.dataset, self.size, self.max_r, self._args, self._kwargs
 
@@ -448,16 +430,6 @@ class PairedNonGeoDataset(NonGeoDataset):
         .. versionadded:: 0.28
         """
         return PairedConcatDataset(self, other)
-
-    # def __getattr__(self, item):
-    #     #if item == "dataset":
-    #     #    return self.dataset
-    #     if item in self.dataset.__dict__:
-    #         return getattr(self.dataset, item)  # pragma: no cover
-    #     elif item in self.__dict__:
-    #         return getattr(self, item)
-    #     else:
-    #         raise AttributeError
 
     def __len__(self) -> int:
         return self.dataset.__len__()

--- a/minerva/datasets/utils.py
+++ b/minerva/datasets/utils.py
@@ -243,7 +243,9 @@ def get_random_sample(
     return dataset[get_random_bounding_box(dataset.bounds, size, res)]
 
 
-def load_dataset_from_cache(cached_dataset_path: Path) -> GeoDataset:
+def load_dataset_from_cache(
+    cached_dataset_path: Path,
+) -> Union[NonGeoDataset, GeoDataset]:
     """Load a pickled dataset object in from a cache.
 
     Args:
@@ -256,7 +258,7 @@ def load_dataset_from_cache(cached_dataset_path: Path) -> GeoDataset:
     with open(cached_dataset_path, "rb") as fp:
         dataset = pickle.load(fp)
 
-    assert isinstance(dataset, GeoDataset)
+    assert isinstance(dataset, (NonGeoDataset, GeoDataset))
     return dataset
 
 

--- a/minerva/utils/runner.py
+++ b/minerva/utils/runner.py
@@ -61,10 +61,10 @@ import requests
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
+import wandb
 from wandb.sdk.lib import RunDisabled
 from wandb.sdk.wandb_run import Run
 
-import wandb
 from minerva.utils import CONFIG, MASTER_PARSER, utils
 
 # =====================================================================================================================

--- a/minerva/utils/runner.py
+++ b/minerva/utils/runner.py
@@ -61,10 +61,10 @@ import requests
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
-import wandb
 from wandb.sdk.lib import RunDisabled
 from wandb.sdk.wandb_run import Run
 
+import wandb
 from minerva.utils import CONFIG, MASTER_PARSER, utils
 
 # =====================================================================================================================
@@ -107,11 +107,19 @@ GENERIC_PARSER.add_argument(
 )
 
 GENERIC_PARSER.add_argument(
-    "--max_epochs",
+    "--max-epochs",
     dest="max_epochs",
     type=int,
     default=100,
     help="Maximum number of training epochs.",
+)
+
+GENERIC_PARSER.add_argument(
+    "--max-r",
+    dest="max_r",
+    type=int,
+    default=32,
+    help="Maximum distance in pixels between samples in a pair.",
 )
 
 GENERIC_PARSER.add_argument(

--- a/tests/test_datasets/test_paired.py
+++ b/tests/test_datasets/test_paired.py
@@ -156,7 +156,6 @@ def test_paired_nongeodatasets(data_root: Path) -> None:
     assert isinstance(sample_2, dict)
 
     assert isinstance(paired_dataset.dataset, NonGeoSSL4EOS12Sentinel2)
-    # assert isinstance(paired_dataset.__getattr__("dataset"), NonGeoSSL4EOS12Sentinel2)
 
     assert isinstance(paired_dataset.__repr__(), str)
 
@@ -183,10 +182,9 @@ def test_paired_concat_datasets(
 
     concat_dataset1 = PairedConcatDataset(dataset1, dataset2, small_patch_size, 16)
     concat_dataset2 = dataset3 | dataset4
-    # concat_dataset3 = concat_dataset1 | dataset3
 
-    # with pytest.raises(ValueError):
-    #    _ = concat_dataset1 | dataset2
+    with pytest.raises(ValueError):
+        _ = concat_dataset1 | dataset2
 
     with pytest.raises(ValueError):
         _ = dataset3 | dataset2
@@ -194,7 +192,6 @@ def test_paired_concat_datasets(
     for dataset in (
         concat_dataset1,
         concat_dataset2,
-        # concat_dataset3,
     ):
         assert isinstance(dataset, PairedConcatDataset)
         dataset_test(dataset)

--- a/tests/test_datasets/test_paired.py
+++ b/tests/test_datasets/test_paired.py
@@ -156,7 +156,7 @@ def test_paired_nongeodatasets(data_root: Path) -> None:
     assert isinstance(sample_2, dict)
 
     assert isinstance(paired_dataset.dataset, NonGeoSSL4EOS12Sentinel2)
-    assert isinstance(paired_dataset.__getattr__("dataset"), NonGeoSSL4EOS12Sentinel2)
+    # assert isinstance(paired_dataset.__getattr__("dataset"), NonGeoSSL4EOS12Sentinel2)
 
     assert isinstance(paired_dataset.__repr__(), str)
 
@@ -181,12 +181,12 @@ def test_paired_concat_datasets(
     dataset3 = PairedNonGeoDataset(NonGeoSSL4EOS12Sentinel2, small_patch_size, 32, root)
     dataset4 = PairedNonGeoDataset(NonGeoSSL4EOS12Sentinel2, small_patch_size, 64, root)
 
-    concat_dataset1 = PairedNonGeoDataset(dataset1 | dataset2, small_patch_size, 16)
+    concat_dataset1 = PairedConcatDataset(dataset1, dataset2, small_patch_size, 16)
     concat_dataset2 = dataset3 | dataset4
-    concat_dataset3 = concat_dataset1 | dataset3
+    # concat_dataset3 = concat_dataset1 | dataset3
 
-    with pytest.raises(ValueError):
-        _ = concat_dataset1 | dataset2
+    # with pytest.raises(ValueError):
+    #    _ = concat_dataset1 | dataset2
 
     with pytest.raises(ValueError):
         _ = dataset3 | dataset2
@@ -194,7 +194,7 @@ def test_paired_concat_datasets(
     for dataset in (
         concat_dataset1,
         concat_dataset2,
-        concat_dataset3,
+        # concat_dataset3,
     ):
         assert isinstance(dataset, PairedConcatDataset)
         dataset_test(dataset)


### PR DESCRIPTION
Small PR to close #309 by adding support for `wandb.sweep`. Also fixes a `RecurssionError` bug from `PairedNonGeoDataset` that cropped up in `wandb.sweep` usage.


>[!NOTE]
Fixing the `RecurssionError` bug required the removal of the `__new__`  and `__getattr__` methods from `PairedNonGeoDataset`. This has resulted in the loss of some flexibility such as being able to create a `PairedConcatDataset` using the constructor of `PairedNonGeoDataset` if the supplied dataset is already a `ConcatDataset`.