### PR TITLE
462 checkpointing dev

### DIFF
--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -255,6 +255,11 @@ class Trainer:
             )
             utils.print_config(dict(params))
 
+        # Set variables for checkpointing the experiment or loading from a previous checkpoint.
+        self.checkpoint_experiment: bool = self.params.get("checkpoint_experiment", False)
+        self.print(f"\nExperiment checkpointing: {self.checkpoint_experiment}")
+        self.resume: bool = self.params.get("resume_experiment", False)
+
         self.params: Dict[str, Any] = dict(params)
         self.batch_size: int = self.params["batch_size"]
         self.model_type: str = self.params["model_type"]
@@ -273,10 +278,11 @@ class Trainer:
         # Sets the timestamp of the experiment.
         self.params["timestamp"] = utils.timestamp_now(fmt="%d-%m-%Y_%H%M")
 
-        # Sets experiment name and adds this to the path to the results' directory.
-        self.params["exp_name"] = "{}_{}".format(
-            self.params["model_name"], self.params["timestamp"]
-        )
+        if not self.resume:
+            # Sets experiment name and adds this to the path to the results' directory.
+            self.params["exp_name"] = "{}_{}".format(
+                self.params["model_name"], self.params["timestamp"]
+            )
 
         # Path to experiment directory and experiment name.
         self.params["dir"]["results"] = universal_path(self.params["dir"]["results"])
@@ -305,6 +311,8 @@ class Trainer:
         if Path(self.params.get("pre_train_name", "none")).suffix == ".onnx":
             # Loads model from `onnx` format.
             self.model = self.load_onnx_model()
+        elif self.resume:
+            self.load_checkpoint()
         else:
             # Creates model (and loss function) from specified parameters in params.
             self.model = self.make_model()
@@ -319,9 +327,6 @@ class Trainer:
         self.sample_pairs = sample_pairs
         self.model.determine_output_dim(sample_pairs=sample_pairs)
 
-        # Transfer to GPU.
-        self.model.to(self.device)
-
         # Sets up the early stopping functionality.
         self.stopper = None
         self.early_stop = False
@@ -333,12 +338,30 @@ class Trainer:
             self.stopper = EarlyStopping(
                 path=f"{self.exp_fn}.pt",
                 trace_func=self.print,
+                external_save=True,
                 **self.params["stopping"],
             )
 
-        # Creates and sets the optimiser for the model.
-        self.make_optimiser()
+        self._setup_writer()
 
+        if not self.resume:
+            # Creates and sets the optimiser for the model.
+            self.make_optimiser()
+
+            # Transfer to GPU.
+            self.model.to(self.device)
+
+            # If writer is `wandb`, `watch` the model to log gradients.
+            if isinstance(self.writer, Run):
+                self.writer.watch(self.model)
+
+            # Checks if multiple GPUs detected. If so, wraps model in DistributedDataParallel for multi-GPU use.
+            # Will also wrap the model in torch.compile if specified to do so in params.
+            self.model = wrap_model(
+                self.model, gpu, self.params.get("torch_compile", False)
+            )
+
+    def _setup_writer(self) -> None:
         if self.gpu == 0:
             if isinstance(self.writer, Run):
                 self.writer.config.update(self.params)
@@ -370,16 +393,6 @@ class Trainer:
                     except RuntimeError as err:  # pragma: no cover
                         print(err)
                         print("ABORT adding graph to writer")
-
-        # If writer is `wandb`, `watch` the model to log gradients.
-        if isinstance(self.writer, Run):
-            self.writer.watch(self.model)
-
-        # Checks if multiple GPUs detected. If so, wraps model in DistributedDataParallel for multi-GPU use.
-        # Will also wrap the model in torch.compile if specified to do so in params.
-        self.model = wrap_model(
-            self.model, gpu, self.params.get("torch_compile", False)
-        )
 
     def get_input_size(self) -> Tuple[int, ...]:
         """Determines the input size of the model.
@@ -551,9 +564,9 @@ class Trainer:
                 **self.params,
             )
 
-        for epoch in range(self.max_epochs):
+        while self.epoch_no < self.max_epochs:
             self.print(
-                f"\nEpoch: {epoch + 1}/{self.max_epochs} =========================================================="
+                f"\nEpoch: {self.epoch_no + 1}/{self.max_epochs} ======================================================"
             )
 
             # Conduct training or validation epoch.
@@ -561,9 +574,9 @@ class Trainer:
                 # Only run a validation epoch at set frequency of epochs. Goes to next epoch if not.
                 if (
                     utils.check_substrings_in_string(mode, "val")
-                    and (epoch + 1) % self.val_freq != 0
+                    and (self.epoch_no + 1) % self.val_freq != 0
                 ):
-                    tasks[mode].log_null(epoch)
+                    tasks[mode].log_null(self.epoch_no)
                     break
 
                 if tasks[mode].train:
@@ -573,23 +586,27 @@ class Trainer:
 
                 results: Optional[Dict[str, Any]]
 
-                results = tasks[mode](epoch)
+                results = tasks[mode](self.epoch_no)
 
                 # Print epoch results.
                 if self.gpu == 0:
-                    tasks[mode].print_epoch_results(epoch)
+                    tasks[mode].print_epoch_results(self.epoch_no)
+                    if not self.stopper and self.checkpoint_experiment:
+                        self.save_checkpoint()
 
                 # Sends validation loss to the stopper and updates early stop bool.
                 if (
                     utils.check_substrings_in_string(mode, "val")
                     and self.stopper is not None
                 ):
-                    val_loss = tasks[mode].get_metrics[f"{mode}_loss"]["y"][epoch]
+                    val_loss = tasks[mode].get_metrics[f"{mode}_loss"]["y"][self.epoch_no]
                     self.stopper(val_loss, self.model)
                     self.early_stop = self.stopper.early_stop
+                    if self.stopper.save_model and self.gpu == 0:
+                        self.save_checkpoint()
 
                 # Special case for final train/ val epoch to plot results if configured so.
-                if epoch == (self.max_epochs - 1) or self.early_stop:
+                if self.epoch_no == (self.max_epochs - 1) or self.early_stop:
                     if self.early_stop and utils.check_substrings_in_string(
                         mode, "val"
                     ):  # pragma: no cover
@@ -616,8 +633,7 @@ class Trainer:
                 # If early stopping has been triggered, loads the last model save to replace current model,
                 # ready for testing.
                 if self.early_stop:  # pragma: no cover
-                    if self.gpu == 0:
-                        self.model.load_state_dict(torch.load(f"{self.exp_fn}.pt"))
+                    self.load_checkpoint()
                     return
 
     def test(self, save: bool = True, show: bool = False) -> None:
@@ -730,9 +746,8 @@ class Trainer:
         torch.save(
             {
                 "epoch": self.epoch_no,
-                "model_state_dict": self.model.state_dict(),
+                "model_state_dict": extract_wrapped_model(self.model).state_dict(),
                 "optimiser_state_dict": optimiser.state_dict(),
-                "params": self.params,
             },
             f"{self.exp_fn}-checkpoint.pt",
         )
@@ -746,7 +761,18 @@ class Trainer:
         self.model.load_state_dict(checkpoint["model-state-dict"])
         self.model.optimiser.load_state_dict(checkpoint["optimiser-state-dict"])  # type: ignore[union-attr]
 
-        self.params = checkpoint["params"]
+        # Transfer to GPU.
+        self.model.to(self.device)
+
+        # If writer is `wandb`, `watch` the model to log gradients.
+        if isinstance(self.writer, Run):
+            self.writer.watch(self.model)
+
+        # Checks if multiple GPUs detected. If so, wraps model in DistributedDataParallel for multi-GPU use.
+        # Will also wrap the model in torch.compile if specified to do so in params.
+        self.model = wrap_model(
+            self.model, self.gpu, self.params.get("torch_compile", False)
+        )
 
         self.epoch_no = checkpoint["epoch"]
 

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -245,6 +245,8 @@ class Trainer:
         # Finds and sets the CUDA device to be used.
         self.device = utils.get_cuda_device(gpu)
 
+        self.params: Dict[str, Any] = dict(params)
+
         # Verbose level. Always 0 if this is not the primary GPU to avoid duplicate stdout statements.
         self.verbose: bool = verbose if gpu == 0 else False
 
@@ -260,7 +262,6 @@ class Trainer:
         self.print(f"\nExperiment checkpointing: {self.checkpoint_experiment}")
         self.resume: bool = self.params.get("resume_experiment", False)
 
-        self.params: Dict[str, Any] = dict(params)
         self.batch_size: int = self.params["batch_size"]
         self.model_type: str = self.params["model_type"]
         self.val_freq: int = self.params.get("val_freq", 1)
@@ -278,7 +279,12 @@ class Trainer:
         # Sets the timestamp of the experiment.
         self.params["timestamp"] = utils.timestamp_now(fmt="%d-%m-%Y_%H%M")
 
-        if not self.resume:
+        if self.resume:
+            try:
+                assert self.params["exp_name"]
+            except AssertionError:
+                raise ValueError("You must add the `exp_name` to the config of the experiment to resume")
+        else:
             # Sets experiment name and adds this to the path to the results' directory.
             self.params["exp_name"] = "{}_{}".format(
                 self.params["model_name"], self.params["timestamp"]

--- a/minerva/transforms.py
+++ b/minerva/transforms.py
@@ -75,7 +75,7 @@ from torch import LongTensor, Tensor
 from torchgeo.datasets import BoundingBox, RasterDataset
 from torchgeo.samplers import RandomGeoSampler
 from torchvision.transforms import ColorJitter, Normalize, RandomApply
-from torchvision.transforms import functional_tensor as ft
+from torchvision.transforms import functional as ft
 
 from minerva.utils.utils import find_tensor_mode, func_by_str, mask_transform
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -189,3 +189,21 @@ def test_trainer_4(
 
     if kwargs.get("test"):
         trainer.test()
+
+
+def test_trainer_resume() -> None:
+    params1 = deepcopy(CONFIG)
+    params1["checkpoint_experiment"] = True
+
+    trainer1 = Trainer(0, **params1)
+    while trainer1.epoch_no < trainer1.max_epochs - 1:
+        trainer1.fit()
+
+    params2 = deepcopy(params1)
+    params2["exp_name"] = params1["exp_name"]
+    params2["resume"] = True
+
+    trainer2 = Trainer(0, **params2)
+
+    trainer2.fit()
+    trainer2.test()

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -194,13 +194,14 @@ def test_trainer_4(
 def test_trainer_resume() -> None:
     params1 = deepcopy(CONFIG)
     params1["checkpoint_experiment"] = True
+    del params1["stopping"]
 
     trainer1 = Trainer(0, **params1)
     while trainer1.epoch_no < trainer1.max_epochs - 1:
         trainer1.fit()
 
     params2 = deepcopy(params1)
-    params2["exp_name"] = params1["exp_name"]
+    params2["exp_name"] = trainer1.params["exp_name"]
     params2["resume"] = True
 
     trainer2 = Trainer(0, **params2)

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -443,7 +443,11 @@ def test_get_centre_loc() -> None:
         ),  # City of London.
         (36.53849331792166, -102.65475905788739, ""),  # Random point in Ohio.
         (30.45028570174185, -76.49581035362436, ""),  # Bermuda Triangle.
-        (41.90204312927206, 12.45644780021287, "Civitas Vaticana"),  # Vatican City.
+        (
+            41.90204312927206,
+            12.45644780021287,
+            "Città del Vaticano, Civitas Vaticana",
+        ),  # Vatican City.
         (-77.844504, 166.707506, "McMurdo Station"),  # McMurdo Station, Antartica.
     ],
 )


### PR DESCRIPTION
This PR adds full checkpointing support to `Trainer`.

New functionality:

* To use checkpointing, set `checkpoint_experiment` to `true` in the config.
* To reload an experiment, set `resume` to `true` and add the experiment to reload to the config in `exp_name`.

> [!NOTE]
> The early stopper will now also use the checkpointing function. This means it'll save a checkpoint that includes the model state dict, rather than just saving the weights.
