### PR TITLE
479 Add Learning Rate Schedulers

### DIFF
--- a/minerva/inbuilt_cfgs/example_GeoSimConvNet.yaml
+++ b/minerva/inbuilt_cfgs/example_GeoSimConvNet.yaml
@@ -42,7 +42,7 @@ fine_tune: false                      # Activate fine-tuning mode.
 
 # ---+ Loss and Optimisers +---------------------------------------------------
 loss_func: &loss_func SegBarlowTwinsLoss  # Name of the loss function to use.
-lr: 1.0E-3                                # Learning rate of optimiser.
+lr: &lr 1.0E-3                                # Learning rate of optimiser.
 optim_func: SGD                           # Name of the optimiser function.
 
 # ---+ SSL/ Siamese Options +--------------------------------------------------
@@ -60,6 +60,14 @@ model_params:
 # ---+ Optimiser Parameters +--------------------------------------------------
 optim_params:
     params:
+
+# ---+ Scheduler Parameters +--------------------------------------------------
+scheduler_params:
+    name: LinearLR
+    params:
+        start_factor: *lr
+        end_factor: 5.0E-4
+        total_iters: 2
 
 # ---+ Loss Function Parameters +----------------------------------------------
 loss_params:

--- a/minerva/inbuilt_cfgs/example_config.yaml
+++ b/minerva/inbuilt_cfgs/example_config.yaml
@@ -57,7 +57,7 @@ scheduler_params:
     params:
         start_factor: 1.0
         end_factor: 0.5
-        total_iters: 30
+        total_iters: 5
 
 # ---+ Loss Function Parameters +----------------------------------------------
 loss_params:

--- a/minerva/inbuilt_cfgs/example_config.yaml
+++ b/minerva/inbuilt_cfgs/example_config.yaml
@@ -51,6 +51,14 @@ model_params:
 optim_params:
     params:
 
+# ---+ Scheduler Parameters +--------------------------------------------------
+scheduler_params:
+    name: LinearLR
+    params:
+        start_factor: 1.0
+        end_factor: 0.5
+        total_iters: 30
+
 # ---+ Loss Function Parameters +----------------------------------------------
 loss_params:
     name: CrossEntropyLoss           # Name of the loss function to use.

--- a/minerva/models/core.py
+++ b/minerva/models/core.py
@@ -82,6 +82,7 @@ from torch.nn.modules import Module
 from torch.nn.parallel import DataParallel
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.optim import Optimizer
+from torch.optim.lr_scheduler import LRScheduler
 from torchvision.models._api import WeightsEnum
 
 from minerva.utils.utils import func_by_str
@@ -153,6 +154,10 @@ class MinervaModel(Module, ABC):
         # torch optimiser. The optimiser MUST be set by calling set_optimiser before the model can be trained.
         self.optimiser: Optional[Optimizer] = None
 
+        # Like the optimiser, the scheduler needs to be set after the model is inited as it needs to wrap
+        # the optimiser. Use ``set_scheduler`` to add the scheduler to the model.
+        self.scheduler: Optional[LRScheduler] = None
+
     def set_optimiser(self, optimiser: Optimizer) -> None:
         """Sets the optimiser used by the model.
 
@@ -166,7 +171,7 @@ class MinervaModel(Module, ABC):
         """
         self.optimiser = optimiser
 
-    def set_scheduler(self, scheduler) -> None:
+    def set_scheduler(self, scheduler: LRScheduler) -> None:
         self.scheduler = scheduler
 
     def set_criterion(self, criterion: Module) -> None:

--- a/minerva/models/core.py
+++ b/minerva/models/core.py
@@ -166,6 +166,9 @@ class MinervaModel(Module, ABC):
         """
         self.optimiser = optimiser
 
+    def set_scheduler(self, scheduler) -> None:
+        self.scheduler = scheduler
+
     def set_criterion(self, criterion: Module) -> None:
         """Set the internal criterion.
 

--- a/minerva/tasks/core.py
+++ b/minerva/tasks/core.py
@@ -341,9 +341,16 @@ class MinervaTask(ABC):
         optimiser_params["params"]["lr"] = self.params["lr"]
 
         # Constructs and sets the optimiser for the model based on supplied config parameters.
-        self.model.set_optimiser(  # type: ignore
-            optimiser(self.model.parameters(), **optimiser_params["params"])
-        )
+        optimiser = optimiser(self.model.parameters(), **optimiser_params["params"])
+        self.model.set_optimiser(optimiser)
+
+        if self.params.get("scheduler_params") is not None:
+            scheduler_params = deepcopy(self.params["scheduler_params"])
+            scheduler = utils.func_by_str(
+                scheduler_params.pop("module", "torch.optim.lr_scheduler"),
+                scheduler_params["name"],
+            )
+            self.model.set_scheduler(scheduler(optimiser, **scheduler_params["params"]))
 
     def make_logger(self) -> MinervaTaskLogger:
         """Creates an object to calculate and log the metrics from the experiment, selected by config parameters.
@@ -409,6 +416,9 @@ class MinervaTask(ABC):
             results = None
 
         self.logger.refresh_step_logger()
+
+        if self.train:
+            self.model.scheduler.step()
 
         return results
 

--- a/minerva/tasks/core.py
+++ b/minerva/tasks/core.py
@@ -417,7 +417,7 @@ class MinervaTask(ABC):
 
         self.logger.refresh_step_logger()
 
-        if self.train:
+        if self.train and self.model.scheduler is not None:
             before_lr = self.model.optimiser.param_groups[0]["lr"]
             self.model.scheduler.step()
             after_lr = self.model.optimiser.param_groups[0]["lr"]

--- a/minerva/tasks/core.py
+++ b/minerva/tasks/core.py
@@ -418,7 +418,10 @@ class MinervaTask(ABC):
         self.logger.refresh_step_logger()
 
         if self.train:
+            before_lr = self.model.optimiser.param_groups[0]["lr"]
             self.model.scheduler.step()
+            after_lr = self.model.optimiser.param_groups[0]["lr"]
+            print(f"lr {before_lr:.4f} -> {after_lr:.4f}")
 
         return results
 

--- a/minerva/trainer.py
+++ b/minerva/trainer.py
@@ -562,9 +562,16 @@ class Trainer:
         optimiser_params["params"]["lr"] = self.params["lr"]
 
         # Constructs and sets the optimiser for the model based on supplied config parameters.
-        self.model.set_optimiser(  # type: ignore
-            optimiser(self.model.parameters(), **optimiser_params["params"])
-        )
+        optimiser = optimiser(self.model.parameters(), **optimiser_params["params"])
+        self.model.set_optimiser(optimiser)
+
+        if self.params.get("scheduler_params") is not None:
+            scheduler_params = deepcopy(self.params["scheduler_params"])
+            scheduler = utils.func_by_str(
+                scheduler_params.pop("module", "torch.optim.lr_scheduler"),
+                scheduler_params["name"],
+            )
+            self.model.set_scheduler(scheduler(optimiser, **scheduler_params["params"]))
 
     def fit(self) -> None:
         """Fits the model by running ``max_epochs`` number of training and validation epochs."""

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -446,7 +446,7 @@ def test_get_centre_loc() -> None:
         (
             41.90204312927206,
             12.45644780021287,
-            "Città del Vaticano, Civitas Vaticana",
+            "Civitas Vaticana",
         ),  # Vatican City.
         (-77.844504, 166.707506, "McMurdo Station"),  # McMurdo Station, Antartica.
     ],


### PR DESCRIPTION
Small PR that adds in learning rate scheduler support. Simply add the parameters for the scheduler to the config in this form:

```
# ---+ Scheduler Parameters +--------------------------------------------------
scheduler_params:
    name: LinearLR
    params:
        start_factor: 1.0
        end_factor: 0.5
        total_iters: 30
```

The scheduler is set to the model just like the optimiser. The step is automatically called as part of the task epoch step. It is also included in the checkpointing system.