### PR TITLE
Removed `catalyst` dependency by copying the needed functionality to `minerva`

### DIFF
--- a/minerva/datasets/factory.py
+++ b/minerva/datasets/factory.py
@@ -59,13 +59,13 @@ import numpy as np
 import pandas as pd
 import torch
 import torch.distributed as dist
-from catalyst.data.sampler import DistributedSamplerWrapper
 from pandas import DataFrame
 from rasterio.crs import CRS
 from torch.utils.data import DataLoader
 from torchgeo.datasets import GeoDataset, RasterDataset
 from torchgeo.samplers import BatchGeoSampler, GeoSampler
 
+from minerva.samplers import DistributedSamplerWrapper
 from minerva.transforms import init_auto_norm, make_transformations
 from minerva.utils import AUX_CONFIGS, CONFIG, universal_path, utils
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
     "alive_progress",
     "argcomplete",
-    "catalyst",
     "geopy",
     "imageio",
     "inputimeout",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,5 @@
 alive_progress==3.1.5
 argcomplete==3.4.0
-catalyst==22.4
 fastapi>=0.101.0
 fiona>=1.9.1
 geopy==2.4.1

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,6 +1,5 @@
 alive_progress==3.1.5
 argcomplete==3.4.0
-catalyst==22.4
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability.
 fastapi>=0.101.0
 fiona>=1.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ install_requires =
         psutil
         alive_progress
         geopy
-        catalyst
         overload
         nptyping
         lightly


### PR DESCRIPTION
This PR closes #500 by removing the `catalyst` dependency which was only needed for the `DistributedSamplerWrapper`. This code has been copied to `minerva` -- with appropriate citations to the source.